### PR TITLE
Move dhash package from core into this repo

### DIFF
--- a/dhash/dhash.go
+++ b/dhash/dhash.go
@@ -1,0 +1,150 @@
+package dhash
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/binary"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multihash"
+)
+
+const (
+	// nonceLen defines length of the nonce to use for AESGCM encryption
+	nonceLen = 12
+)
+
+var (
+	// secondHashPrefix is a prefix that a mulithash is prepended with when calculating a second hash
+	secondHashPrefix = []byte("CR_DOUBLEHASH\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	// deriveKeyPrefix is a prefix that a multihash is prepended with when deriving an encryption key
+	deriveKeyPrefix = []byte("CR_ENCRYPTIONKEY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	// noncePrefix is a prefix that a multihash is prepended with when calculating a nonce
+	noncePrefix = []byte("CR_NONCE\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+)
+
+// SecondSHA returns SHA256 over the payload
+func SHA256(payload, dest []byte) []byte {
+	return sha256Multiple(dest, payload)
+}
+
+func sha256Multiple(dest []byte, payloads ...[]byte) []byte {
+	h := sha256.New()
+	for _, payload := range payloads {
+		h.Write(payload)
+	}
+	return h.Sum(dest)
+}
+
+// SecondMultihash calculates SHA256 over the multihash and wraps it into another multihash with DBL_SHA256 codec
+func SecondMultihash(mh multihash.Multihash) (multihash.Multihash, error) {
+	digest := SHA256(append(secondHashPrefix, mh...), nil)
+	return multihash.Encode(digest, multihash.DBL_SHA2_256)
+}
+
+// deriveKey derives encryptioin key from the passphrase using SHA256
+func deriveKey(passphrase []byte) []byte {
+	return SHA256(append(deriveKeyPrefix, passphrase...), nil)
+}
+
+// DecryptAES decrypts AES payload using the nonce and the passphrase
+func DecryptAES(nonce, payload, passphrase []byte) ([]byte, error) {
+	key := deriveKey(passphrase)
+	b, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return aesgcm.Open(nil, nonce, payload, nil)
+}
+
+// encryptAES uses AESGCM to encrypt the payload with the passphrase and a nonce derived from it.
+// returns nonce and encrypted bytes.
+func EncryptAES(payload, passphrase []byte) ([]byte, []byte, error) {
+	// Derive the encryption key
+	derivedKey := deriveKey([]byte(passphrase))
+
+	// Create initialization vector (nonse) to be used during encryption
+	// Nonce is derived from the passphrase concatenated with the payload so that the encrypted payloads
+	// for the same multihash can be compared to each other without having to decrypt them, as it's not possible.
+	payloadLen := make([]byte, 8)
+	binary.LittleEndian.PutUint64(payloadLen, uint64(len(payload)))
+	nonce := sha256Multiple(nil, noncePrefix, payloadLen, payload, passphrase)[:nonceLen]
+
+	// Create cypher and seal the data
+	block, err := aes.NewCipher(derivedKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	encrypted := aesgcm.Seal(nil, nonce, []byte(payload), nil)
+
+	return nonce, encrypted, nil
+}
+
+// DecryptValueKey decrypts the value key using the passphrase
+func DecryptValueKey(valKey, mh multihash.Multihash) ([]byte, error) {
+	return DecryptAES(valKey[:nonceLen], valKey[nonceLen:], mh)
+}
+
+// EncryptValueKey encrypts raw value key using the passpharse
+func EncryptValueKey(valKey, mh multihash.Multihash) ([]byte, error) {
+	nonce, encValKey, err := EncryptAES(valKey, mh)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(nonce, encValKey...), nil
+}
+
+// DecryptMetadata decrypts metdata using the provided passphrase
+func DecryptMetadata(encMetadata, valueKey []byte) ([]byte, error) {
+	return DecryptAES(encMetadata[:nonceLen], encMetadata[nonceLen:], valueKey)
+}
+
+// EncryptMetadata encrypts metadata using the provided passphrase
+func EncryptMetadata(metadata, valueKey []byte) ([]byte, error) {
+	nonce, encValKey, err := EncryptAES(metadata, valueKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(nonce, encValKey...), nil
+}
+
+// CreateValueKey creates value key from peer ID and context ID
+func CreateValueKey(pid peer.ID, ctxID []byte) []byte {
+	var b bytes.Buffer
+	b.Grow(len(string(pid)) + len(ctxID))
+	b.WriteString(string(pid))
+	b.Write(ctxID)
+	return b.Bytes()
+}
+
+// SplitValueKey splits value key into original components
+func SplitValueKey(valKey []byte) (peer.ID, []byte, error) {
+	// Extract multihiash from the value key before converting it to peer.ID.
+	// Extracting peer.ID directly would fail the length check. There is no overhead in doing that as
+	// none of the operations allocates new memory.
+	l, mh, err := multihash.MHFromBytes(valKey)
+	if err != nil {
+		return "", nil, err
+	}
+	pid, err := peer.IDFromBytes(mh)
+	if err != nil {
+		return "", nil, err
+	}
+	return pid, valKey[l:], nil
+}

--- a/dhash/dhash_test.go
+++ b/dhash/dhash_test.go
@@ -1,0 +1,76 @@
+package dhash
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"math/rand"
+	"testing"
+
+	"github.com/ipni/go-libipni/internal/test"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSalt(t *testing.T) {
+	salt_len := 64
+	require.Equal(t, len(secondHashPrefix), salt_len)
+	require.Equal(t, len(deriveKeyPrefix), salt_len)
+	require.Equal(t, len(noncePrefix), salt_len)
+}
+
+func TestEncryptSameValueWithTheSameMultihashShouldProduceTheSameOutput(t *testing.T) {
+	rng := rand.New(rand.NewSource(1413))
+	payload := make([]byte, 256)
+	_, err := rng.Read(payload)
+	if err != nil {
+		panic(err)
+	}
+	passphrase := make([]byte, 32)
+	_, err = rng.Read(passphrase)
+	require.NoError(t, err)
+
+	nonce1, encrypted1, err := EncryptAES(payload, passphrase)
+	require.NoError(t, err)
+
+	nonce2, encrypted2, err := EncryptAES(payload, passphrase)
+	require.NoError(t, err)
+
+	require.True(t, bytes.Equal(nonce1, nonce2))
+	require.True(t, bytes.Equal(encrypted1, encrypted2))
+}
+
+func TestCanDecryptEncryptedValue(t *testing.T) {
+	rng := rand.New(rand.NewSource(1413))
+	payload := make([]byte, 256)
+	_, err := rng.Read(payload)
+	if err != nil {
+		panic(err)
+	}
+	passphrase := make([]byte, 32)
+	_, err = rng.Read(passphrase)
+	require.NoError(t, err)
+
+	nonce, encrypted, err := EncryptAES(payload, passphrase)
+	require.NoError(t, err)
+
+	decrypted, err := DecryptAES(nonce, encrypted, passphrase)
+	require.NoError(t, err)
+
+	require.True(t, bytes.Equal(payload, decrypted))
+}
+
+func TestSecondMultihash(t *testing.T) {
+	mh := test.RandomMultihashes(1)[0]
+	smh, err := SecondMultihash(mh)
+	require.NoError(t, err)
+
+	h := sha256.New()
+	h.Write(append(secondHashPrefix, mh...))
+	digest := h.Sum(nil)
+
+	decoded, err := multihash.Decode(smh)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(multihash.DBL_SHA2_256), decoded.Code)
+	require.Equal(t, digest, decoded.Digest)
+}

--- a/find/client/http/dhash_client.go
+++ b/find/client/http/dhash_client.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/ipni/dhstore"
-	"github.com/ipni/go-indexer-core/store/dhash"
 	"github.com/ipni/go-libipni/apierror"
+	"github.com/ipni/go-libipni/dhash"
 	"github.com/ipni/go-libipni/find/model"
 	"github.com/libp2p/go-libp2p/core/peer"
 	b58 "github.com/mr-tron/base58/base58"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad
-	github.com/ipni/go-indexer-core v0.7.5
 	github.com/libp2p/go-libp2p v0.26.4
 	github.com/libp2p/go-libp2p-pubsub v0.9.0
 	github.com/libp2p/go-msgio v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,6 @@ github.com/ipld/go-ipld-prime v0.20.0 h1:Ud3VwE9ClxpO2LkCYP7vWPc0Fo+dYdYzgxUJZ3u
 github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawdGVlJDE8kK+M=
 github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad h1:nS2Zq9bHG0eFzRjz1naWKl6I1YYPGWI1yWJK+zX3UGM=
 github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad/go.mod h1:XI6XW5Eu97zY5PEK2ZRuESh8mYkxIZYRTMcknPVbbrc=
-github.com/ipni/go-indexer-core v0.7.5 h1:NJDp7SJwZr7QMtz207IvI9+WXAHvVeQmbfZwDWsjFY4=
-github.com/ipni/go-indexer-core v0.7.5/go.mod h1:oOXgBf2YU8vC9pPf8YeGOkvQYU4/ND+vo+Hff0hd56Q=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=


### PR DESCRIPTION
The dhash package contains logis that is needed by both the ingestion and by a dhclient, so it should reside in go-libipni. Other parties writing ipni clients should not depend on out core implementation, so go-libipni should not have a dependency on go-indexer-core.