### PR TITLE
Add IPFS Gateway HTTP transport metadata as a well-known multicodec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.9.0
-	github.com/multiformats/go-multicodec v0.8.1
+	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/multiformats/go-multistream v0.4.1
 	github.com/multiformats/go-varint v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/g
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multibase v0.2.0 h1:isdYCVLvksgWlMW9OZRYJEa9pZETFivncJHmHnnd87g=
 github.com/multiformats/go-multibase v0.2.0/go.mod h1:bFBZX4lKCA/2lyOFSAoKH5SS6oPyjtnzK/XTFDPkNuk=
-github.com/multiformats/go-multicodec v0.8.1 h1:ycepHwavHafh3grIbR1jIXnKCsFm0fqsfEOsJ8NtKE8=
-github.com/multiformats/go-multicodec v0.8.1/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
+github.com/multiformats/go-multicodec v0.9.0 h1:pb/dlPnzee/Sxv/j4PmkDRxCOi3hXTz3IbPKOXWJkmg=
+github.com/multiformats/go-multicodec v0.9.0/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multihash v0.0.9/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/metadata/ipfs_trustless_gateway.go
+++ b/metadata/ipfs_trustless_gateway.go
@@ -1,0 +1,54 @@
+package metadata
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-varint"
+)
+
+var (
+	ipfsGatewayHttpBytes           = append(varint.ToUvarint(uint64(multicodec.TransportIpfsGatewayHttp)), ipfsGatewayHttpPayloadLenBytes...)
+	ipfsGatewayHttpPayloadLenBytes = varint.ToUvarint(0)
+
+	_ Protocol = (*IpfsGatewayHttp)(nil)
+)
+
+// IpfsGatewayHttp represents the indexing metadata that uses multicodec.TransportIpfsGatewayHttp.
+type IpfsGatewayHttp struct {
+}
+
+func (b IpfsGatewayHttp) ID() multicodec.Code {
+	return multicodec.TransportIpfsGatewayHttp
+}
+
+func (b IpfsGatewayHttp) MarshalBinary() ([]byte, error) {
+	return ipfsGatewayHttpBytes, nil
+}
+
+func (b IpfsGatewayHttp) UnmarshalBinary(data []byte) error {
+	if !bytes.Equal(data, ipfsGatewayHttpBytes) {
+		return fmt.Errorf("transport ID does not match %s", multicodec.TransportIpfsGatewayHttp)
+	}
+	return nil
+}
+
+func (b IpfsGatewayHttp) ReadFrom(r io.Reader) (n int64, err error) {
+	wantLen := len(ipfsGatewayHttpBytes)
+	buf := make([]byte, wantLen)
+	read, err := r.Read(buf)
+	bRead := int64(read)
+	if err != nil {
+		return bRead, err
+	}
+	if wantLen != read {
+		return bRead, fmt.Errorf("expected %d readable bytes but read %d", wantLen, read)
+	}
+
+	if !bytes.Equal(ipfsGatewayHttpBytes, buf) {
+		return bRead, fmt.Errorf("transport ID does not match %s", multicodec.TransportIpfsGatewayHttp)
+	}
+	return bRead, nil
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -64,6 +64,7 @@ func init() {
 	}
 	d.protocols[multicodec.TransportBitswap] = func() Protocol { return &Bitswap{} }
 	d.protocols[multicodec.TransportGraphsyncFilecoinv1] = func() Protocol { return &GraphsyncFilecoinV1{} }
+	d.protocols[multicodec.TransportIpfsGatewayHttp] = func() Protocol { return &IpfsGatewayHttp{} }
 	Default = &d
 }
 


### PR DESCRIPTION
Add SDK to aid parsing IPNI metadata that represents IPFS Gateway HTTP transport protocol.

Relates to:
 - https://github.com/multiformats/multicodec/pull/321

Fixes #21