### PR TITLE
Fix empty error messages

### DIFF
--- a/apierror/error.go
+++ b/apierror/error.go
@@ -42,8 +42,16 @@ func New(err error, status int) *Error {
 	}
 }
 
-func FromResponse(status int, body []byte) *Error {
-	return New(errors.New(strings.TrimSpace(string(body))), status)
+func FromResponse(status int, body []byte) error {
+	var err error
+	text := strings.TrimSpace(string(body))
+	if text != "" {
+		err = errors.New(text)
+	}
+	if status == 0 {
+		return err
+	}
+	return New(err, status)
 }
 
 func (e *Error) Error() string {

--- a/apierror/error.go
+++ b/apierror/error.go
@@ -126,6 +126,9 @@ func DecodeError(data []byte) error {
 		return fmt.Errorf("cannot decode error message: %s", err)
 	}
 
-	apierr := New(errors.New(e.Message), e.Status)
-	return errors.New(apierr.Text())
+	err = errors.New(e.Message)
+	if e.Status == 0 {
+		return err
+	}
+	return New(err, e.Status)
 }

--- a/apierror/error_test.go
+++ b/apierror/error_test.go
@@ -14,8 +14,8 @@ func TestNew(t *testing.T) {
 	err := apierror.New(errors.New("test error"), 0)
 	require.Equal(t, "test error", err.Error())
 
-	err = apierror.New(nil, 404)
-	require.Equal(t, fmt.Sprintf("404 %s", http.StatusText(404)), err.Error())
+	err = apierror.New(nil, http.StatusNotFound)
+	require.Equal(t, fmt.Sprintf("%d %s", http.StatusNotFound, http.StatusText(http.StatusNotFound)), err.Error())
 
 	err = apierror.New(nil, 0)
 	require.Equal(t, "", err.Error())
@@ -28,15 +28,15 @@ func TestFromResponse(t *testing.T) {
 	err := apierror.FromResponse(0, []byte(" hello world\n"))
 	require.Equal(t, "hello world", err.Error())
 
-	err = apierror.FromResponse(418, []byte(" hello world\n"))
+	err = apierror.FromResponse(http.StatusTeapot, []byte(" hello world\n"))
 	require.Equal(t, "hello world", err.Error())
 
 	ae, ok := err.(*apierror.Error)
 	require.True(t, ok)
-	require.Equal(t, 418, ae.Status())
+	require.Equal(t, http.StatusTeapot, ae.Status())
 
-	err = apierror.FromResponse(418, nil)
-	require.Equal(t, fmt.Sprintf("418 %s", http.StatusText(418)), err.Error())
+	err = apierror.FromResponse(http.StatusTeapot, nil)
+	require.Equal(t, fmt.Sprintf("%d %s", http.StatusTeapot, http.StatusText(http.StatusTeapot)), err.Error())
 }
 
 func TestEncodeDecode(t *testing.T) {
@@ -49,7 +49,7 @@ func TestEncodeDecode(t *testing.T) {
 	derr = apierror.DecodeError([]byte("hello world"))
 	require.ErrorContains(t, derr, "cannot decode error message")
 
-	err := apierror.New(errors.New("cannot find it"), 404)
+	err := apierror.New(errors.New("cannot find it"), http.StatusNotFound)
 	data = apierror.EncodeError(err)
 
 	derr = apierror.DecodeError(data)
@@ -57,8 +57,8 @@ func TestEncodeDecode(t *testing.T) {
 
 	ae, ok := derr.(*apierror.Error)
 	require.True(t, ok)
-	require.Equal(t, 404, ae.Status())
-	require.Equal(t, fmt.Sprintf("404 %s: cannot find it", http.StatusText(404)), ae.Text())
+	require.Equal(t, http.StatusNotFound, ae.Status())
+	require.Equal(t, fmt.Sprintf("%d %s: cannot find it", http.StatusNotFound, http.StatusText(http.StatusNotFound)), ae.Text())
 
 	someErr := errors.New("some error")
 	data = apierror.EncodeError(someErr)

--- a/apierror/error_test.go
+++ b/apierror/error_test.go
@@ -1,0 +1,76 @@
+package apierror_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ipni/go-libipni/apierror"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	err := apierror.New(errors.New("test error"), 0)
+	require.Equal(t, "test error", err.Error())
+
+	err = apierror.New(nil, 404)
+	require.Equal(t, fmt.Sprintf("404 %s", http.StatusText(404)), err.Error())
+
+	err = apierror.New(nil, 0)
+	require.Equal(t, "", err.Error())
+
+	err = apierror.New(nil, 999)
+	require.Equal(t, "999", err.Error())
+}
+
+func TestFromResponse(t *testing.T) {
+	err := apierror.FromResponse(0, []byte(" hello world\n"))
+	require.Equal(t, "hello world", err.Error())
+
+	err = apierror.FromResponse(418, []byte(" hello world\n"))
+	require.Equal(t, "hello world", err.Error())
+
+	ae, ok := err.(*apierror.Error)
+	require.True(t, ok)
+	require.Equal(t, 418, ae.Status())
+
+	err = apierror.FromResponse(418, nil)
+	require.Equal(t, fmt.Sprintf("418 %s", http.StatusText(418)), err.Error())
+}
+
+func TestEncodeDecode(t *testing.T) {
+	data := apierror.EncodeError(nil)
+	require.Nil(t, data)
+
+	derr := apierror.DecodeError(nil)
+	require.Nil(t, derr)
+
+	derr = apierror.DecodeError([]byte("hello world"))
+	require.ErrorContains(t, derr, "cannot decode error message")
+
+	err := apierror.New(errors.New("cannot find it"), 404)
+	data = apierror.EncodeError(err)
+
+	derr = apierror.DecodeError(data)
+	require.Equal(t, "cannot find it", derr.Error())
+
+	ae, ok := derr.(*apierror.Error)
+	require.True(t, ok)
+	require.Equal(t, 404, ae.Status())
+	require.Equal(t, fmt.Sprintf("404 %s: cannot find it", http.StatusText(404)), ae.Text())
+
+	someErr := errors.New("some error")
+	data = apierror.EncodeError(someErr)
+
+	derr = apierror.DecodeError(data)
+	require.Equal(t, "some error", derr.Error())
+	_, ok = derr.(*apierror.Error)
+	require.False(t, ok)
+}
+
+func TestUnwrap(t *testing.T) {
+	errEOF := errors.New("end of file")
+	err := apierror.New(errEOF, 0)
+	require.ErrorIs(t, err, errEOF)
+}


### PR DESCRIPTION
When an error such as a 404 occurrs, and it does not have any message in the response body, use the status text instead of creating an empty error. The empty error is confusing and problematic for logging what happened.