### PR TITLE
Make provider cache threadsafe

### DIFF
--- a/find/client/http/dhash_client.go
+++ b/find/client/http/dhash_client.go
@@ -1,7 +1,6 @@
 package httpclient
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -14,7 +13,6 @@ import (
 	"github.com/ipni/go-libipni/apierror"
 	"github.com/ipni/go-libipni/dhash"
 	"github.com/ipni/go-libipni/find/model"
-	"github.com/libp2p/go-libp2p/core/peer"
 	b58 "github.com/mr-tron/base58/base58"
 	"github.com/multiformats/go-multihash"
 )
@@ -28,8 +26,7 @@ const (
 var log = logging.Logger("dhash-client")
 
 type DHashClient struct {
-	Client
-
+	c             *http.Client
 	dhFindURL     *url.URL
 	dhMetadataURL *url.URL
 	pcache        *providerCache
@@ -43,30 +40,31 @@ type DHashClient struct {
 // can respond to find provider requests. dhstoreURL and stiURL are expected to
 // be the same when these services are deployed behing a proxy - indexstar.
 func NewDHashClient(dhstoreURL, stiURL string, options ...Option) (*DHashClient, error) {
-	c, err := New(stiURL, options...)
+	opts, err := getOpts(options)
 	if err != nil {
 		return nil, err
 	}
 
-	if !strings.HasPrefix(dhstoreURL, "http://") && !strings.HasPrefix(dhstoreURL, "https://") {
-		dhstoreURL = "http://" + dhstoreURL
+	dhsURL, err := parseUrl(dhstoreURL)
+	if err != nil {
+		return nil, err
 	}
-	dhsURL, err := url.Parse(dhstoreURL)
+
+	sURL, err := parseUrl(stiURL)
+	if err != nil {
+		return nil, err
+	}
+
+	pcache, err := newProviderCache(sURL, opts.httpClient)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DHashClient{
-		Client:        *c,
+		c:             opts.httpClient,
 		dhFindURL:     dhsURL.JoinPath(findPath),
 		dhMetadataURL: dhsURL.JoinPath(metadataPath),
-		pcache: &providerCache{
-			ttl:    pcacheTTL,
-			pinfos: make(map[peer.ID]*pinfoWrapper),
-			pinfoFetcher: func(ctx context.Context, pid peer.ID) (*model.ProviderInfo, error) {
-				return c.GetProvider(ctx, pid)
-			},
-		},
+		pcache:        pcache,
 	}, nil
 }
 
@@ -80,16 +78,22 @@ func (c *DHashClient) Find(ctx context.Context, mh multihash.Multihash) (*model.
 	mhr := model.MultihashResult{
 		Multihash: mh,
 	}
-	for pr := range resChan {
-		mhr.ProviderResults = append(mhr.ProviderResults, pr)
+
+	for {
+		select {
+		case pr, ok := <-resChan:
+			if !ok {
+				return &model.FindResponse{
+					MultihashResults: []model.MultihashResult{mhr},
+				}, nil
+			}
+			mhr.ProviderResults = append(mhr.ProviderResults, pr)
+		case e, ok := <-errChan:
+			if ok {
+				return nil, e
+			}
+		}
 	}
-	err := <-errChan
-	if err != nil {
-		return nil, err
-	}
-	return &model.FindResponse{
-		MultihashResults: []model.MultihashResult{mhr},
-	}, nil
 }
 
 // FindAsync implements double hashed lookup workflow. It submits results as they get decrypted and assembled into resChan. If an error occurs it is sent to errChan.
@@ -103,17 +107,20 @@ func (c *DHashClient) FindAsync(ctx context.Context, mh multihash.Multihash, res
 	smh, err := dhash.SecondMultihash(mh)
 	if err != nil {
 		errChan <- err
+		return
 	}
 	u := c.dhFindURL.JoinPath(smh.B58String())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		errChan <- err
+		return
 	}
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := c.c.Do(req)
 	if err != nil {
 		errChan <- err
+		return
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -121,16 +128,19 @@ func (c *DHashClient) FindAsync(ctx context.Context, mh multihash.Multihash, res
 
 	if err != nil {
 		errChan <- err
+		return
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		errChan <- apierror.FromResponse(resp.StatusCode, body)
+		return
 	}
 
 	encResponse := &model.FindResponse{}
 	err = json.Unmarshal(body, encResponse)
 	if err != nil {
 		errChan <- err
+		return
 	}
 
 	for _, emhrs := range encResponse.EncryptedMultihashResults {
@@ -213,118 +223,9 @@ func (c *DHashClient) fetchMetadata(ctx context.Context, vk []byte) ([]byte, err
 	return dhash.DecryptMetadata(findResponse.EncryptedMetadata, vk)
 }
 
-// providerCache caches ProviderInfo objects as well as indexes
-// ContextualExtendedProviders by ContextID. ProviderInfos are evicted from the
-// cache after ttl. Missing / expired ProviderInfos are refreshed via
-// pinfoFetcher function.
-//
-// This struct is designed to be independent from double hashed client itself
-// so that it can be used in the libp2p client once it materialises.
-type providerCache struct {
-	ttl          time.Duration
-	pinfos       map[peer.ID]*pinfoWrapper
-	pinfoFetcher func(ctx context.Context, pid peer.ID) (*model.ProviderInfo, error)
-}
-
-type pinfoWrapper struct {
-	ts    time.Time
-	pinfo *model.ProviderInfo
-	cxps  map[string]*model.ContextualExtendedProviders
-}
-
-func (pc *providerCache) getResults(ctx context.Context, pid peer.ID, ctxID []byte, metadata []byte) ([]model.ProviderResult, error) {
-	wrapper := pc.pinfos[pid]
-
-	// If ProviderInfo isn't in the cache or if the record has expired - try to
-	// fetch a new ProviderInfo and update the cache
-	if wrapper == nil || time.Since(wrapper.ts) > pc.ttl {
-		pinfo, err := pc.pinfoFetcher(ctx, pid)
-		if err != nil {
-			return nil, err
-		}
-
-		wrapper = &pinfoWrapper{
-			ts:    time.Now(),
-			pinfo: pinfo,
-			cxps:  make(map[string]*model.ContextualExtendedProviders),
-		}
-		pc.pinfos[pinfo.AddrInfo.ID] = wrapper
-		if pinfo.ExtendedProviders != nil {
-			for _, cxp := range pinfo.ExtendedProviders.Contextual {
-				wrapper.cxps[cxp.ContextID] = &cxp
-			}
-		}
+func parseUrl(su string) (*url.URL, error) {
+	if !strings.HasPrefix(su, "http://") && !strings.HasPrefix(su, "https://") {
+		su = "http://" + su
 	}
-
-	results := make([]model.ProviderResult, 0, 1)
-
-	results = append(results, model.ProviderResult{
-		ContextID: ctxID,
-		Metadata:  metadata,
-		Provider:  &wrapper.pinfo.AddrInfo,
-	})
-
-	// return results if there are no further extended providers to unpack
-	if wrapper.pinfo.ExtendedProviders == nil {
-		return results, nil
-	}
-
-	// If override is set to true at the context level then the chain
-	// level EPs should be ignored for this context ID
-	override := false
-
-	// Adding context-level EPs if they exist
-	if contextualEpRecord, ok := wrapper.cxps[string(ctxID)]; ok {
-		override = contextualEpRecord.Override
-		for i, xpinfo := range contextualEpRecord.Providers {
-			xmd := contextualEpRecord.Metadatas[i]
-			// Skippng the main provider's record if its metadata is nil or is
-			// the same as the one retrieved from the indexer, because such EP
-			// record does not advertise any new protocol.
-			if xpinfo.ID == wrapper.pinfo.AddrInfo.ID &&
-				(len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
-				continue
-			}
-			// Use metadata from advertisement if one hasn't been specified for
-			// the extended provider
-			if xmd == nil {
-				xmd = metadata
-			}
-
-			results = append(results, model.ProviderResult{
-				ContextID: ctxID,
-				Metadata:  xmd,
-				Provider:  &xpinfo,
-			})
-		}
-	}
-
-	// If override is true then don't include chain-level EPs
-	if override {
-		return results, nil
-	}
-
-	// Adding chain-level EPs if such exist
-	for i, xpinfo := range wrapper.pinfo.ExtendedProviders.Providers {
-		xmd := wrapper.pinfo.ExtendedProviders.Metadatas[i]
-		// Skippng the main provider's record if its metadata is nil or is the
-		// same as the one retrieved from the indexer, because such EP record
-		// does not advertise any new protocol.
-		if xpinfo.ID == wrapper.pinfo.AddrInfo.ID &&
-			(len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
-			continue
-		}
-		// Use metadata from advertisement if one hasn't been specified for the
-		// extended provider
-		if xmd == nil {
-			xmd = metadata
-		}
-		results = append(results, model.ProviderResult{
-			ContextID: ctxID,
-			Metadata:  xmd,
-			Provider:  &xpinfo,
-		})
-	}
-
-	return results, nil
+	return url.Parse(su)
 }

--- a/find/client/http/provider_cache.go
+++ b/find/client/http/provider_cache.go
@@ -1,0 +1,194 @@
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/ipni/go-libipni/apierror"
+	"github.com/ipni/go-libipni/find/model"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// providerCache caches ProviderInfo objects as well as indexes
+// ContextualExtendedProviders by ContextID. ProviderInfos are evicted from the
+// cache after ttl. Missing / expired ProviderInfos get fetched from the pURL.
+//
+// This struct is designed to be independent from double hashed client itself
+// so that it can be used in the libp2p client once it materialises.
+//
+// Safe to be used concurrently.
+type providerCache struct {
+	ttl    time.Duration
+	lock   sync.RWMutex
+	pinfos map[peer.ID]*pinfoWrapper
+	pUrl   *url.URL
+	c      *http.Client
+}
+
+// NewProviderCache creates a new provider cache that can be sahred across multiple clients.
+func newProviderCache(u *url.URL, c *http.Client) (*providerCache, error) {
+	pUrl := u.JoinPath(providersPath)
+
+	if c == nil {
+		c = http.DefaultClient
+	}
+
+	return &providerCache{
+		ttl:    pcacheTTL,
+		pUrl:   pUrl,
+		c:      c,
+		pinfos: make(map[peer.ID]*pinfoWrapper),
+	}, nil
+}
+
+type pinfoWrapper struct {
+	ts    time.Time
+	pinfo *model.ProviderInfo
+	cxps  map[string]*model.ContextualExtendedProviders
+}
+
+func (pc *providerCache) getPInfoWrapper(pid peer.ID) *pinfoWrapper {
+	pc.lock.RLock()
+	defer pc.lock.RUnlock()
+	return pc.pinfos[pid]
+}
+
+func (pc *providerCache) setPInforWrapper(pid peer.ID, wrapper *pinfoWrapper) {
+	pc.lock.Lock()
+	defer pc.lock.Unlock()
+	pc.pinfos[pid] = wrapper
+}
+
+func (pc *providerCache) fetchPInfo(ctx context.Context, pid peer.ID) (*model.ProviderInfo, error) {
+	u := pc.pUrl.JoinPath(pid.String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := pc.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, apierror.FromResponse(resp.StatusCode, body)
+	}
+
+	var providerInfo model.ProviderInfo
+	err = json.Unmarshal(body, &providerInfo)
+	if err != nil {
+		return nil, err
+	}
+	return &providerInfo, nil
+}
+
+func (pc *providerCache) getResults(ctx context.Context, pid peer.ID, ctxID []byte, metadata []byte) ([]model.ProviderResult, error) {
+	wrapper := pc.getPInfoWrapper(pid)
+
+	// If ProviderInfo isn't in the cache or if the record has expired - try to
+	// fetch a new ProviderInfo and update the cache
+	if wrapper == nil || time.Since(wrapper.ts) > pc.ttl {
+		pinfo, err := pc.fetchPInfo(ctx, pid)
+		if err != nil {
+			return nil, err
+		}
+
+		wrapper = &pinfoWrapper{
+			ts:    time.Now(),
+			pinfo: pinfo,
+			cxps:  make(map[string]*model.ContextualExtendedProviders),
+		}
+		if pinfo.ExtendedProviders != nil {
+			for _, cxp := range pinfo.ExtendedProviders.Contextual {
+				wrapper.cxps[cxp.ContextID] = &cxp
+			}
+		}
+		pc.setPInforWrapper(pid, wrapper)
+	}
+
+	results := make([]model.ProviderResult, 0, 1)
+
+	results = append(results, model.ProviderResult{
+		ContextID: ctxID,
+		Metadata:  metadata,
+		Provider:  &wrapper.pinfo.AddrInfo,
+	})
+
+	// return results if there are no further extended providers to unpack
+	if wrapper.pinfo.ExtendedProviders == nil {
+		return results, nil
+	}
+
+	// If override is set to true at the context level then the chain
+	// level EPs should be ignored for this context ID
+	override := false
+
+	// Adding context-level EPs if they exist
+	if contextualEpRecord, ok := wrapper.cxps[string(ctxID)]; ok {
+		override = contextualEpRecord.Override
+		for i, xpinfo := range contextualEpRecord.Providers {
+			xmd := contextualEpRecord.Metadatas[i]
+			// Skippng the main provider's record if its metadata is nil or is
+			// the same as the one retrieved from the indexer, because such EP
+			// record does not advertise any new protocol.
+			if xpinfo.ID == wrapper.pinfo.AddrInfo.ID &&
+				(len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
+				continue
+			}
+			// Use metadata from advertisement if one hasn't been specified for
+			// the extended provider
+			if xmd == nil {
+				xmd = metadata
+			}
+
+			results = append(results, model.ProviderResult{
+				ContextID: ctxID,
+				Metadata:  xmd,
+				Provider:  &xpinfo,
+			})
+		}
+	}
+
+	// If override is true then don't include chain-level EPs
+	if override {
+		return results, nil
+	}
+
+	// Adding chain-level EPs if such exist
+	for i, xpinfo := range wrapper.pinfo.ExtendedProviders.Providers {
+		xmd := wrapper.pinfo.ExtendedProviders.Metadatas[i]
+		// Skippng the main provider's record if its metadata is nil or is the
+		// same as the one retrieved from the indexer, because such EP record
+		// does not advertise any new protocol.
+		if xpinfo.ID == wrapper.pinfo.AddrInfo.ID &&
+			(len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
+			continue
+		}
+		// Use metadata from advertisement if one hasn't been specified for the
+		// extended provider
+		if xmd == nil {
+			xmd = metadata
+		}
+		results = append(results, model.ProviderResult{
+			ContextID: ctxID,
+			Metadata:  xmd,
+			Provider:  &xpinfo,
+		})
+	}
+
+	return results, nil
+}

--- a/find/client/http/provider_cache.go
+++ b/find/client/http/provider_cache.go
@@ -180,7 +180,7 @@ func (pc *providerCache) getResults(ctx context.Context, pid peer.ID, ctxID []by
 		}
 		// Use metadata from advertisement if one hasn't been specified for the
 		// extended provider
-		if xmd == nil {
+		if len(xmd) == 0 {
 			xmd = metadata
 		}
 		results = append(results, model.ProviderResult{


### PR DESCRIPTION
* Move provider cache to a separate file
* Make provider cache thread safe so that the double hashed client can be used concurrently
* This optimisation will reduce dhfind latency significantly (at least by a third) as well as will allow to save up on memory