### PR TITLE
Ignore multiaddrs with unknown protocols

### DIFF
--- a/announce/message/message.go
+++ b/announce/message/message.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multiaddr"
@@ -38,13 +39,17 @@ func (m *Message) SetAddrs(addrs []multiaddr.Multiaddr) {
 // GetAddrs reads the slice of Multiaddr that is stored in the Message as a
 // slice of []byte.
 func (m *Message) GetAddrs() ([]multiaddr.Multiaddr, error) {
-	addrs := make([]multiaddr.Multiaddr, len(m.Addrs))
-	for i := range m.Addrs {
-		var err error
-		addrs[i], err = multiaddr.NewMultiaddrBytes(m.Addrs[i])
+	addrs := make([]multiaddr.Multiaddr, 0, len(m.Addrs))
+	for _, addrBytes := range m.Addrs {
+		addr, err := multiaddr.NewMultiaddrBytes(addrBytes)
 		if err != nil {
+			if strings.Contains(err.Error(), "no protocol with code") {
+				// Ignore unknown protocols.
+				continue
+			}
 			return nil, err
 		}
+		addrs = append(addrs, addr)
 	}
 	return addrs, nil
 }

--- a/announce/message/message_test.go
+++ b/announce/message/message_test.go
@@ -73,3 +73,18 @@ func TestJSON(t *testing.T) {
 
 	require.Equal(t, msg, newMsg)
 }
+
+func TestUnknownProtocol(t *testing.T) {
+	// Encoded unknown protocol code 9999: /ip4/127.0.0.1/udp/1234/<proto-9999>
+	addrData := []byte{54, 9, 108, 111, 99, 97, 108, 104, 111, 115, 116, 145, 2, 4, 210, 143, 78}
+	_, err := multiaddr.NewMultiaddrBytes(addrData)
+	require.ErrorContains(t, err, "no protocol with code")
+
+	var msg message.Message
+	msg.SetAddrs([]multiaddr.Multiaddr{maddr1})
+	msg.Addrs = append(msg.Addrs, addrData)
+
+	addrs, err := msg.GetAddrs()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(addrs))
+}


### PR DESCRIPTION
If new protocols, unknown to the indexer or assigner service, are encoded into multiaddrs in announce messages, then ignore these. This will allow older indexers to accept messages even when newer address types are included.

Fixes issue #29