### PR TITLE
feat(dagsync/httpsync): add NewPublisherForListener w/ existing Listener

### DIFF
--- a/dagsync/httpsync/publisher.go
+++ b/dagsync/httpsync/publisher.go
@@ -89,7 +89,7 @@ func NewPublisher(address string, lsys ipld.LinkSystem, privKey ic.PrivKey, opti
 	return pub, nil
 }
 
-// NewPublisherForListener creates a new http publisher for an existing,
+// NewPublisherForListener creates a new http publisher for an existing
 // listener. When providing an existing listener, running the HTTP server
 // is the caller's responsibility. ServeHTTP on the returned Publisher
 // can be used to handle requests. handlerPath is the path to handle
@@ -113,16 +113,17 @@ func NewPublisherForListener(listener net.Listener, handlerPath string, lsys ipl
 		return nil, err
 	}
 	proto, _ := multiaddr.NewMultiaddr("/http")
+	handlerPath = strings.TrimPrefix(handlerPath, "/")
 	if handlerPath != "" {
-		httpath, err := multiaddr.NewComponent("httpath", url.PathEscape(strings.TrimLeft(handlerPath, "/")))
+		httpath, err := multiaddr.NewComponent("httpath", url.PathEscape(handlerPath))
 		if err != nil {
 			return nil, err
 		}
 		proto = multiaddr.Join(proto, httpath)
-		if !strings.HasPrefix(handlerPath, "/") {
-			handlerPath = "/" + handlerPath
-		}
+		handlerPath = "/" + handlerPath
 	}
+
+	fmt.Println("w addr", multiaddr.Join(maddr, proto).String())
 
 	return &Publisher{
 		addr:        multiaddr.Join(maddr, proto),

--- a/dagsync/httpsync/publisher.go
+++ b/dagsync/httpsync/publisher.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
@@ -25,15 +27,16 @@ import (
 )
 
 type Publisher struct {
-	addr      multiaddr.Multiaddr
-	closer    io.Closer
-	lsys      ipld.LinkSystem
-	peerID    peer.ID
-	privKey   ic.PrivKey
-	rl        sync.RWMutex
-	root      cid.Cid
-	senders   []announce.Sender
-	extraData []byte
+	addr        multiaddr.Multiaddr
+	closer      io.Closer
+	lsys        ipld.LinkSystem
+	handlerPath string
+	peerID      peer.ID
+	privKey     ic.PrivKey
+	rl          sync.RWMutex
+	root        cid.Cid
+	senders     []announce.Sender
+	extraData   []byte
 }
 
 var _ http.Handler = (*Publisher)(nil)
@@ -84,6 +87,53 @@ func NewPublisher(address string, lsys ipld.LinkSystem, privKey ic.PrivKey, opti
 	go server.Serve(l)
 
 	return pub, nil
+}
+
+// NewPublisherForListener creates a new http publisher for an existing,
+// listener. When providing an existing listener, running the HTTP server
+// is the caller's responsibility. ServeHTTP on the returned Publisher
+// can be used to handle requests. handlerPath is the path to handle
+// requests on, e.g. "ipni" for `/ipni/...` requests.
+func NewPublisherForListener(listener net.Listener, handlerPath string, lsys ipld.LinkSystem, privKey ic.PrivKey, options ...Option) (*Publisher, error) {
+	opts, err := getOpts(options)
+	if err != nil {
+		return nil, err
+	}
+
+	if privKey == nil {
+		return nil, errors.New("private key required to sign head requests")
+	}
+	peerID, err := peer.IDFromPrivateKey(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not get peer id from private key: %w", err)
+	}
+
+	maddr, err := manet.FromNetAddr(listener.Addr())
+	if err != nil {
+		return nil, err
+	}
+	proto, _ := multiaddr.NewMultiaddr("/http")
+	if handlerPath != "" {
+		httpath, err := multiaddr.NewComponent("httpath", url.PathEscape(strings.TrimLeft(handlerPath, "/")))
+		if err != nil {
+			return nil, err
+		}
+		proto = multiaddr.Join(proto, httpath)
+		if !strings.HasPrefix(handlerPath, "/") {
+			handlerPath = "/" + handlerPath
+		}
+	}
+
+	return &Publisher{
+		addr:        multiaddr.Join(maddr, proto),
+		closer:      io.NopCloser(nil),
+		lsys:        lsys,
+		handlerPath: handlerPath,
+		peerID:      peerID,
+		privKey:     privKey,
+		senders:     opts.senders,
+		extraData:   opts.extraData,
+	}, nil
 }
 
 // Addrs returns the addresses, as []multiaddress, that the Publisher is
@@ -170,7 +220,16 @@ func (p *Publisher) Close() error {
 }
 
 func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ask := path.Base(r.URL.Path)
+	var ask string
+	if p.handlerPath != "" {
+		if !strings.HasPrefix(r.URL.Path, p.handlerPath) {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		ask = path.Base(strings.TrimPrefix(r.URL.Path, p.handlerPath))
+	} else {
+		ask = path.Base(r.URL.Path)
+	}
 	if ask == "head" {
 		// serve the head
 		p.rl.RLock()

--- a/dagsync/httpsync/publisher_test.go
+++ b/dagsync/httpsync/publisher_test.go
@@ -1,0 +1,168 @@
+package httpsync_test
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/linking"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/storage/memstore"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/ipni/go-libipni/dagsync/httpsync"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPublisherForListener(t *testing.T) {
+	req := require.New(t)
+	ctx := context.Background()
+
+	store := &correctedMemStore{&memstore.Store{
+		Bag: make(map[string][]byte),
+	}}
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.TrustedStorage = true
+	lsys.SetReadStorage(store)
+	lsys.SetWriteStorage(store)
+	rootLnk, err := lsys.Store(linking.LinkContext{}, cidlink.LinkPrototype{Prefix: cid.Prefix{Version: 1, Codec: 0x0129, MhType: 0x12, MhLength: 32}}, basicnode.NewString("borp"))
+	req.NoError(err)
+
+	for _, handlerPath := range []string{"", "/", "boop/bop", "/boop/bop"} {
+		t.Run("with path "+handlerPath, func(t *testing.T) {
+			addr, err := net.ResolveTCPAddr("tcp", "192.168.200.1:8080")
+			req.NoError(err)
+			l := fakeListener{addr}
+			privKey, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
+			req.NoError(err)
+			subject, err := httpsync.NewPublisherForListener(l, handlerPath, lsys, privKey)
+			req.NoError(err)
+			subject.SetRoot(ctx, rootLnk.(cidlink.Link).Cid)
+			resp := &mockResponseWriter{}
+			u := &url.URL{
+				Path: handlerPath + "/head",
+			}
+			if !strings.HasPrefix(handlerPath, "/") {
+				u.Path = "/" + u.Path
+			}
+			subject.ServeHTTP(resp, &http.Request{URL: u})
+			req.Equal(0, resp.status) // not explicitly set
+			req.Nil(resp.header)
+			respNode, err := ipld.Decode(resp.body, dagjson.Decode)
+			req.NoError(err)
+			headCid := mustCid(t, respNode, ipld.ParsePath("/head"))
+			req.Equal(rootLnk.(cidlink.Link).Cid, headCid)
+			expectedPubkey, err := ic.MarshalPublicKey(privKey.GetPublic())
+			req.NoError(err)
+			pubkey := mustBytes(t, respNode, ipld.ParsePath("/pubkey"))
+			req.Equal(expectedPubkey, pubkey)
+			expectedSig, err := privKey.Sign(rootLnk.(cidlink.Link).Cid.Bytes())
+			req.NoError(err)
+			sig := mustBytes(t, respNode, ipld.ParsePath("/sig"))
+			req.Equal(expectedSig, sig)
+			// nothing extra?
+			req.ElementsMatch([]string{"head", "pubkey", "sig"}, mapKeys(t, respNode))
+		})
+	}
+}
+
+func mapKeys(t *testing.T, n ipld.Node) []string {
+	var keys []string
+	require.Equal(t, n.Kind(), datamodel.Kind_Map)
+	mi := n.MapIterator()
+	for !mi.Done() {
+		k, _, err := mi.Next()
+		require.NoError(t, err)
+		require.Equal(t, k.Kind(), datamodel.Kind_String)
+		ks, err := k.AsString()
+		require.NoError(t, err)
+		keys = append(keys, ks)
+	}
+	return keys
+}
+
+func mustCid(t *testing.T, n ipld.Node, path ipld.Path) cid.Cid {
+	for path.Len() > 0 {
+		var err error
+		var ps ipld.PathSegment
+		ps, path = path.Shift()
+		n, err = n.LookupBySegment(ps)
+		require.NoError(t, err)
+	}
+	require.Equal(t, n.Kind(), datamodel.Kind_Link)
+	lnkNode, err := n.AsLink()
+	require.NoError(t, err)
+	return lnkNode.(cidlink.Link).Cid
+}
+
+func mustBytes(t *testing.T, n ipld.Node, path ipld.Path) []byte {
+	c, err := traversal.Get(n, path)
+	require.NoError(t, err)
+	require.Equal(t, c.Kind(), datamodel.Kind_Bytes)
+	b, err := c.AsBytes()
+	require.NoError(t, err)
+	return b
+}
+
+type fakeListener struct {
+	addr net.Addr
+}
+
+func (l fakeListener) Accept() (c net.Conn, err error) { return }
+func (l fakeListener) Close() error                    { return nil }
+func (l fakeListener) Addr() net.Addr                  { return l.addr }
+
+type mockResponseWriter struct {
+	header http.Header
+	body   []byte
+	status int
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	if m.header == nil {
+		m.header = make(http.Header)
+	}
+	return m.header
+}
+
+func (m *mockResponseWriter) Write(data []byte) (int, error) {
+	m.body = append(m.body, data...)
+	return len(data), nil
+}
+
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+	m.status = statusCode
+}
+
+// TODO: remove when this is fixed in IPLD prime
+type correctedMemStore struct {
+	*memstore.Store
+}
+
+func (cms *correctedMemStore) Get(ctx context.Context, key string) ([]byte, error) {
+	data, err := cms.Store.Get(ctx, key)
+	if err != nil && err.Error() == "404" {
+		err = format.ErrNotFound{}
+	}
+	return data, err
+}
+
+func (cms *correctedMemStore) GetStream(ctx context.Context, key string) (io.ReadCloser, error) {
+	rc, err := cms.Store.GetStream(ctx, key)
+	if err != nil && err.Error() == "404" {
+		err = format.ErrNotFound{}
+	}
+	return rc, err
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-graphsync v0.14.6
+	github.com/ipfs/go-ipld-format v0.3.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/libp2p/go-libp2p v0.27.3
@@ -66,7 +67,6 @@ require (
 	github.com/ipfs/go-ipfs-pq v0.0.2 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
 	github.com/ipfs/go-ipld-cbor v0.0.5 // indirect
-	github.com/ipfs/go-ipld-format v0.3.0 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.5.0 // indirect


### PR DESCRIPTION
Is this OK? I think I want to use an http publisher but on an existing server. With this I should be able to make a listener and an http server, start the publisher as `pub` with that listener and attach to a `mux.HandleFunc("/some/path", pub.ServeHttp)` for it.

Doing a bit of 🤞 that `httpath` is going to be properly handled in the announcement so the request will come back in on the right path. I haven't followed that logic through to see if it's actually going to work but since `maurl` is being used then I'm hopeful.

Also, is `httpath` something that could be made official?