### PR TITLE
Unmarshal metadata with unknown transport ID into Unknown metadata

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -217,5 +217,5 @@ func (mc *metadataContext) newTransport(id multicodec.Code) (Protocol, error) {
 		return factory(), nil
 	}
 
-	return nil, fmt.Errorf("unknown transport id: %s", id.String())
+	return &Unknown{}, nil
 }


### PR DESCRIPTION
Instead of returning an error when a metadata with an unknown transport ID is found, read the data into an Unknown metadata type and add it to the list of decoded metadatas. This allows any unknown metadata types, that are unknown to the reader, to be skipped.

This requires that all metadata types other than bitswap and graphsync, encode the payload length following the metadata transport ID.

Fixes #27