### PR TITLE
Add http client that adds sharding key

### DIFF
--- a/find/client/http/sharding_http_client.go
+++ b/find/client/http/sharding_http_client.go
@@ -1,0 +1,62 @@
+package httpclient
+
+import (
+	"net/http"
+	"path"
+
+	"github.com/ipfs/go-cid"
+)
+
+const (
+	shardKeyHeader = "x-ipni-dhstore-shard-key"
+	cidPath        = "cid"
+)
+
+// ShardingRoundTripper adds x-ipni-dhstore-shard-key header to all GET requests for metadata, cid and multihash.
+type ShardingRoundTripper struct {
+	http.RoundTripper
+}
+
+// NewShardingClient creates a new http.Client with ShardingRoundTripper transport. The client should be used for sharded metadata, cid and multihash lookups only.
+// Using the client for other purposes will not make any harm but will not bring any benefits either.
+func NewShardingClient() *http.Client {
+	return &http.Client{
+		Transport: &ShardingRoundTripper{
+			RoundTripper: http.DefaultTransport,
+		},
+	}
+}
+
+// RoundTrip adds x-ipni-dhstore-shard-key header to all GET requests for metadata, cid and multihash.
+// It follows the following rules:
+//   - If this is not a GET request - do nothing;
+//   - If the request path conforms to ".../metadata/XYZ" - then XYZ will be set as x-ipni-dhstore-shard-key header as-is;
+//   - If the request path conforms to ".../cid/XYZ" or ".../multihash/XYZ" -  the last path of the URL will be treated as cid/multihash and will be parsed with cid.Decode.
+//     If that succeeds - B58 of the Multihash will be added as x-ipni-dhstore-shard-key header. Otherwise no x-ipni-dhstore-shard-key will be added.
+func (cr *ShardingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Method == http.MethodGet {
+		var u, object, objectId, shardKey string
+		u = r.URL.Path
+		u, objectId = path.Split(u)
+		// the remaining url should be at least as long as "/cid/"
+		if len(u) < len(cidPath)+2 {
+			goto DEFAULT
+		}
+		// don't forget to remove the last "/"
+		_, object = path.Split(u[:len(u)-1])
+		if object == metadataPath {
+			shardKey = objectId
+		} else if (object == findPath) || (object == cidPath) {
+			// it's safe to use cid.Decode for both cids and multihashes. In the latter case, the string will be trated as B58 encoded multihash.
+			c, err := cid.Decode(objectId)
+			if err == nil {
+				shardKey = c.Hash().B58String()
+			}
+		}
+		if len(shardKey) > 0 {
+			r.Header.Set(shardKeyHeader, shardKey)
+		}
+	}
+DEFAULT:
+	return cr.RoundTripper.RoundTrip(r)
+}

--- a/find/client/http/sharding_http_client_test.go
+++ b/find/client/http/sharding_http_client_test.go
@@ -18,9 +18,9 @@ func TestShardingClient(t *testing.T) {
 			return
 		}
 		if strings.Contains(u, "cid") {
-			require.Equal(t, "QmUtQvv4erpcYDyoL8jgzXHqy9dQUi3a5gGTVDSdDicw4x", r.Header.Get(shardKeyHeader))
+			require.Equal(t, "2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", r.Header.Get(shardKeyHeader))
 		} else if strings.Contains(u, "multihash") {
-			require.Equal(t, "QmZ7nrfFMcrnroRWkZCAiALDEYK5Z5gkEFsSMAaoFfQmAw", r.Header.Get(shardKeyHeader))
+			require.Equal(t, "2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", r.Header.Get(shardKeyHeader))
 		} else if strings.Contains(u, "metadata") {
 			require.Equal(t, "ABCD", r.Header.Get(shardKeyHeader))
 		} else {
@@ -29,11 +29,11 @@ func TestShardingClient(t *testing.T) {
 	}))
 
 	c := NewShardingClient()
-	sendRequest(t, c, server.URL+"/multihash/QmZ7nrfFMcrnroRWkZCAiALDEYK5Z5gkEFsSMAaoFfQmAw", http.MethodGet)
-	sendRequest(t, c, server.URL+"/cid/bafybeidbjeqjovk2zdwh2dngy7tckid7l7qab5wivw2v5es4gphqxvsqqu", http.MethodGet)
+	sendRequest(t, c, server.URL+"/multihash/2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", http.MethodGet)
+	sendRequest(t, c, server.URL+"/cid/bafyfmiglbrdanius5to5ugztnscfor6ovqf2ufbf5edkk46pqw2j4tsvvq", http.MethodGet)
 	sendRequest(t, c, server.URL+"/metadata/ABCD", http.MethodGet)
-	sendRequest(t, c, server.URL+"/someOthePath/ABCD", http.MethodGet)
-	sendRequest(t, c, server.URL+"/someOthePath/ABCD", http.MethodPost)
+	sendRequest(t, c, server.URL+"/someOtherPath/ABCD", http.MethodGet)
+	sendRequest(t, c, server.URL+"/someOtherPath/ABCD", http.MethodPost)
 }
 
 func sendRequest(t *testing.T, c *http.Client, u, method string) {

--- a/find/client/http/sharding_http_client_test.go
+++ b/find/client/http/sharding_http_client_test.go
@@ -17,9 +17,9 @@ func TestShardingClient(t *testing.T) {
 			require.Equal(t, "", r.Header.Get(shardKeyHeader))
 			return
 		}
-		if strings.Contains(u, "cid") {
+		if strings.Contains(u, "cid/bafyfmiglbrdanius5to5ugztnscfor6ovqf2ufbf5edkk46pqw2j4tsvvq") {
 			require.Equal(t, "2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", r.Header.Get(shardKeyHeader))
-		} else if strings.Contains(u, "multihash") {
+		} else if strings.Contains(u, "multihash/2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o") {
 			require.Equal(t, "2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", r.Header.Get(shardKeyHeader))
 		} else if strings.Contains(u, "metadata") {
 			require.Equal(t, "ABCD", r.Header.Get(shardKeyHeader))
@@ -29,8 +29,11 @@ func TestShardingClient(t *testing.T) {
 	}))
 
 	c := NewShardingClient()
-	sendRequest(t, c, server.URL+"/multihash/2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", http.MethodGet)
-	sendRequest(t, c, server.URL+"/cid/bafyfmiglbrdanius5to5ugztnscfor6ovqf2ufbf5edkk46pqw2j4tsvvq", http.MethodGet)
+
+	sendRequest(t, c, server.URL+"/multihash/2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", http.MethodGet)       // double hashed multihash
+	sendRequest(t, c, server.URL+"/multihash/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn", http.MethodGet)        // regular multihash - should be no headers
+	sendRequest(t, c, server.URL+"/cid/bafyfmiglbrdanius5to5ugztnscfor6ovqf2ufbf5edkk46pqw2j4tsvvq", http.MethodGet) // double hashed cid
+	sendRequest(t, c, server.URL+"/cid/bafybeidbjeqjovk2zdwh2dngy7tckid7l7qab5wivw2v5es4gphqxvsqqu", http.MethodGet) // regular cid should be no headers
 	sendRequest(t, c, server.URL+"/metadata/ABCD", http.MethodGet)
 	sendRequest(t, c, server.URL+"/someOtherPath/ABCD", http.MethodGet)
 	sendRequest(t, c, server.URL+"/someOtherPath/ABCD", http.MethodPost)

--- a/find/client/http/sharding_http_client_test.go
+++ b/find/client/http/sharding_http_client_test.go
@@ -1,0 +1,44 @@
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardingClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := r.URL.Path
+		if r.Method != http.MethodGet {
+			require.Equal(t, "", r.Header.Get(shardKeyHeader))
+			return
+		}
+		if strings.Contains(u, "cid") {
+			require.Equal(t, "QmUtQvv4erpcYDyoL8jgzXHqy9dQUi3a5gGTVDSdDicw4x", r.Header.Get(shardKeyHeader))
+		} else if strings.Contains(u, "multihash") {
+			require.Equal(t, "QmZ7nrfFMcrnroRWkZCAiALDEYK5Z5gkEFsSMAaoFfQmAw", r.Header.Get(shardKeyHeader))
+		} else if strings.Contains(u, "metadata") {
+			require.Equal(t, "ABCD", r.Header.Get(shardKeyHeader))
+		} else {
+			require.Equal(t, "", r.Header.Get(shardKeyHeader))
+		}
+	}))
+
+	c := NewShardingClient()
+	sendRequest(t, c, server.URL+"/multihash/QmZ7nrfFMcrnroRWkZCAiALDEYK5Z5gkEFsSMAaoFfQmAw", http.MethodGet)
+	sendRequest(t, c, server.URL+"/cid/bafybeidbjeqjovk2zdwh2dngy7tckid7l7qab5wivw2v5es4gphqxvsqqu", http.MethodGet)
+	sendRequest(t, c, server.URL+"/metadata/ABCD", http.MethodGet)
+	sendRequest(t, c, server.URL+"/someOthePath/ABCD", http.MethodGet)
+	sendRequest(t, c, server.URL+"/someOthePath/ABCD", http.MethodPost)
+}
+
+func sendRequest(t *testing.T, c *http.Client, u, method string) {
+	req, err := http.NewRequestWithContext(context.Background(), method, u, nil)
+	require.NoError(t, err)
+	_, err = c.Do(req)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Add http client that sets sharding headers for GET `metadata`, `cid` and `multihash` lookups. The client is safe to be used as a general purpose http client however it won't add much benefit outside of the scope of IPNI sharding.

A custom http client is required because we'd like to be able to set sharding headers inside `DHashClient` without exposing sharding semantics to the users.

Sharding headers inside `DHashClient` are required in the scope of `dhfind`. Requests sent from `dhfind` won't be proxied through `indexstar` and hence won't be enriched with the right sharding headers.