### PR TITLE
Move dhstore URL to dhash_client options

### DIFF
--- a/find/client/dhash_client.go
+++ b/find/client/dhash_client.go
@@ -36,16 +36,9 @@ type DHashClient struct {
 // querying data. It requires more roundtrips to fullfill one query however it
 // also protects the user from a passive observer. dhstoreURL specifies the URL
 // of the double hashed store that can respond to find encrypted multihash and
-// find encrypted metadata requests. stiURL specifies the URL of indexer that
-// can respond to find provider requests. dhstoreURL and stiURL are expected to
-// be the same when these services are deployed behing a proxy - indexstar.
-func NewDHashClient(dhstoreURL, stiURL string, options ...Option) (*DHashClient, error) {
+// find encrypted metadata requests.
+func NewDHashClient(stiURL string, options ...Option) (*DHashClient, error) {
 	opts, err := getOpts(options)
-	if err != nil {
-		return nil, err
-	}
-
-	dhsURL, err := parseUrl(dhstoreURL)
 	if err != nil {
 		return nil, err
 	}
@@ -53,6 +46,14 @@ func NewDHashClient(dhstoreURL, stiURL string, options ...Option) (*DHashClient,
 	sURL, err := parseUrl(stiURL)
 	if err != nil {
 		return nil, err
+	}
+
+	dhsURL := sURL
+	if len(opts.dhstoreUrl) > 0 {
+		dhsURL, err = parseUrl(opts.dhstoreUrl)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	pcache, err := newProviderCache(sURL, opts.httpClient)

--- a/find/client/http/old_client.go
+++ b/find/client/http/old_client.go
@@ -16,5 +16,5 @@ type DHashClient = client.DHashClient
 
 // Deprecated: Use github.com/ipni/go-libipni/find/client
 func NewDHashClient(dhstoreURL, stiURL string, options ...client.Option) (*client.DHashClient, error) {
-	return client.NewDHashClient(dhstoreURL, stiURL, options...)
+	return client.NewDHashClient(stiURL, append(options, client.WithDHStoreUrl(dhstoreURL))...)
 }

--- a/find/client/option.go
+++ b/find/client/option.go
@@ -7,6 +7,7 @@ import (
 
 type config struct {
 	httpClient *http.Client
+	dhstoreUrl string
 }
 
 // Option is a function that sets a value in a config.
@@ -30,6 +31,16 @@ func getOpts(opts []Option) (config, error) {
 func WithClient(c *http.Client) Option {
 	return func(cfg *config) error {
 		cfg.httpClient = c
+		return nil
+	}
+}
+
+// WithDHStoreUrl allows specifying different URLs for dhstore (/multihash and /metadata endpoints) and storetheindex (/providers endpoint).
+// This might be useful as dhstore and storetheindex are different services that might not necessarily be behind the same URL. However
+// the data from both of them is required to assemble results.
+func WithDHStoreUrl(u string) Option {
+	return func(cfg *config) error {
+		cfg.dhstoreUrl = u
 		return nil
 	}
 }

--- a/find/client/option.go
+++ b/find/client/option.go
@@ -7,7 +7,7 @@ import (
 
 type config struct {
 	httpClient *http.Client
-	dhstoreUrl string
+	dhstoreURL string
 }
 
 // Option is a function that sets a value in a config.

--- a/find/client/option.go
+++ b/find/client/option.go
@@ -7,7 +7,7 @@ import (
 
 type config struct {
 	httpClient *http.Client
-	dhstoreURL string
+	dhstoreUrl string
 }
 
 // Option is a function that sets a value in a config.
@@ -35,12 +35,12 @@ func WithClient(c *http.Client) Option {
 	}
 }
 
-// WithDHStoreURL allows specifying different URLs for dhstore (/multihash and /metadata endpoints) and storetheindex (/providers endpoint).
+// WithDHStoreUrl allows specifying different URLs for dhstore (/multihash and /metadata endpoints) and storetheindex (/providers endpoint).
 // This might be useful as dhstore and storetheindex are different services that might not necessarily be behind the same URL. However
 // the data from both of them is required to assemble results.
-func WithDHStoreURL(u string) Option {
+func WithDHStoreUrl(u string) Option {
 	return func(cfg *config) error {
-		cfg.dhstoreURL = u
+		cfg.dhstoreUrl = u
 		return nil
 	}
 }

--- a/find/client/option.go
+++ b/find/client/option.go
@@ -35,12 +35,12 @@ func WithClient(c *http.Client) Option {
 	}
 }
 
-// WithDHStoreUrl allows specifying different URLs for dhstore (/multihash and /metadata endpoints) and storetheindex (/providers endpoint).
+// WithDHStoreURL allows specifying different URLs for dhstore (/multihash and /metadata endpoints) and storetheindex (/providers endpoint).
 // This might be useful as dhstore and storetheindex are different services that might not necessarily be behind the same URL. However
 // the data from both of them is required to assemble results.
-func WithDHStoreUrl(u string) Option {
+func WithDHStoreURL(u string) Option {
 	return func(cfg *config) error {
-		cfg.dhstoreUrl = u
+		cfg.dhstoreURL = u
 		return nil
 	}
 }


### PR DESCRIPTION
Having these two URLs separate might be confusing for users as most of the times they are going to be the same. 