### PR TITLE
Track last synced

### DIFF
--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -52,11 +52,10 @@ func TestAnnounceReplace(t *testing.T) {
 	// Store the whole chain in source node
 	chainLnks := test.MkChain(srcLnkS, true)
 
-	hnd, err := sub.getOrCreateHandler(srcHost.ID())
-	require.NoError(t, err)
+	hnd := sub.getOrCreateHandler(srcHost.ID())
 
 	// Lock mutex inside sync handler to simulate publisher blocked in graphsync.
-	hnd.syncMutex.Lock()
+	hnd.subscriber.scopedBlockHookMutex.Lock()
 
 	firstCid := chainLnks[2].(cidlink.Link).Cid
 	err = pub.SetRoot(context.Background(), firstCid)
@@ -104,7 +103,7 @@ func TestAnnounceReplace(t *testing.T) {
 	}, 2*time.Second, 100*time.Millisecond)
 
 	// Unblock the first handler goroutine
-	hnd.syncMutex.Unlock()
+	hnd.subscriber.scopedBlockHookMutex.Unlock()
 
 	// Validate that sink for first CID happened.
 	select {

--- a/dagsync/latestsync.go
+++ b/dagsync/latestsync.go
@@ -1,0 +1,34 @@
+package dagsync
+
+import (
+	"sync"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// LatestSyncHandler defines how to store the latest synced cid for a given
+// peer and how to fetch it. dagsync guarantees this will not be called
+// concurrently for the same peer, but it may be called concurrently for
+// different peers.
+type LatestSyncHandler interface {
+	SetLatestSync(peer peer.ID, cid cid.Cid)
+	GetLatestSync(peer peer.ID) (cid.Cid, bool)
+}
+
+type DefaultLatestSyncHandler struct {
+	m sync.Map
+}
+
+func (h *DefaultLatestSyncHandler) SetLatestSync(p peer.ID, c cid.Cid) {
+	log.Infow("Updating latest sync", "cid", c, "peer", p)
+	h.m.Store(p, c)
+}
+
+func (h *DefaultLatestSyncHandler) GetLatestSync(p peer.ID) (cid.Cid, bool) {
+	v, ok := h.m.Load(p)
+	if !ok {
+		return cid.Undef, false
+	}
+	return v.(cid.Cid), true
+}

--- a/dagsync/latestsync.go
+++ b/dagsync/latestsync.go
@@ -7,25 +7,19 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// LatestSyncHandler defines how to store the latest synced cid for a given
+// latestSyncHandler defines how to store the latest synced cid for a given
 // peer and how to fetch it. dagsync guarantees this will not be called
 // concurrently for the same peer, but it may be called concurrently for
 // different peers.
-type LatestSyncHandler interface {
-	SetLatestSync(peer peer.ID, cid cid.Cid)
-	GetLatestSync(peer peer.ID) (cid.Cid, bool)
-}
-
-type DefaultLatestSyncHandler struct {
+type latestSyncHandler struct {
 	m sync.Map
 }
 
-func (h *DefaultLatestSyncHandler) SetLatestSync(p peer.ID, c cid.Cid) {
-	log.Infow("Updating latest sync", "cid", c, "peer", p)
+func (h *latestSyncHandler) setLatestSync(p peer.ID, c cid.Cid) {
 	h.m.Store(p, c)
 }
 
-func (h *DefaultLatestSyncHandler) GetLatestSync(p peer.ID) (cid.Cid, bool) {
+func (h *latestSyncHandler) getLatestSync(p peer.ID) (cid.Cid, bool) {
 	v, ok := h.m.Load(p)
 	if !ok {
 		return cid.Undef, false

--- a/dagsync/option.go
+++ b/dagsync/option.go
@@ -6,10 +6,12 @@ import (
 	"time"
 
 	dt "github.com/filecoin-project/go-data-transfer/v2"
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipni/go-libipni/announce"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 const (
@@ -27,6 +29,8 @@ const (
 	defaultGsMaxOutRequests = 1024
 )
 
+type LastKnownSyncFunc func(peer.ID) (cid.Cid, bool)
+
 // config contains all options for configuring Subscriber.
 type config struct {
 	addrTTL   time.Duration
@@ -43,8 +47,8 @@ type config struct {
 
 	syncRecLimit selector.RecursionLimit
 
-	idleHandlerTTL    time.Duration
-	latestSyncHandler LatestSyncHandler
+	idleHandlerTTL time.Duration
+	lastKnownSync  LastKnownSyncFunc
 
 	resendAnnounce bool
 
@@ -186,18 +190,21 @@ func WithMaxGraphsyncRequests(maxIn, maxOut uint64) Option {
 	}
 }
 
-// UseLatestSyncHandler sets the latest sync handler to use.
-func UseLatestSyncHandler(h LatestSyncHandler) Option {
+// WithLastKnownSync sets a function that returns the last known sync, when it
+// is not already known to dagsync. This will generally be some CID that is
+// known to have already been seen, so that there is no need to fetch portions
+// of the dag before this.
+func WithLastKnownSync(f LastKnownSyncFunc) Option {
 	return func(c *config) error {
-		c.latestSyncHandler = h
+		c.lastKnownSync = f
 		return nil
 	}
 }
 
 type syncCfg struct {
-	alwaysUpdateLatest bool
-	scopedBlockHook    BlockHookFunc
-	segDepthLimit      int64
+	forceUpdateLatest bool
+	scopedBlockHook   BlockHookFunc
+	segDepthLimit     int64
 }
 
 type SyncOption func(*syncCfg)
@@ -211,9 +218,9 @@ func getSyncOpts(opts []SyncOption) syncCfg {
 	return cfg
 }
 
-func AlwaysUpdateLatest() SyncOption {
+func WithForceUpdateLatest() SyncOption {
 	return func(sc *syncCfg) {
-		sc.alwaysUpdateLatest = true
+		sc.forceUpdateLatest = true
 	}
 }
 

--- a/dagsync/option.go
+++ b/dagsync/option.go
@@ -3,16 +3,13 @@ package dagsync
 import (
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	dt "github.com/filecoin-project/go-data-transfer/v2"
-	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipni/go-libipni/announce"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 const (
@@ -187,32 +184,6 @@ func WithMaxGraphsyncRequests(maxIn, maxOut uint64) Option {
 		c.gsMaxOutRequests = maxOut
 		return nil
 	}
-}
-
-// LatestSyncHandler defines how to store the latest synced cid for a given
-// peer and how to fetch it. dagsync guarantees this will not be called
-// concurrently for the same peer, but it may be called concurrently for
-// different peers.
-type LatestSyncHandler interface {
-	SetLatestSync(peer peer.ID, cid cid.Cid)
-	GetLatestSync(peer peer.ID) (cid.Cid, bool)
-}
-
-type DefaultLatestSyncHandler struct {
-	m sync.Map
-}
-
-func (h *DefaultLatestSyncHandler) SetLatestSync(p peer.ID, c cid.Cid) {
-	log.Infow("Updating latest sync", "cid", c, "peer", p)
-	h.m.Store(p, c)
-}
-
-func (h *DefaultLatestSyncHandler) GetLatestSync(p peer.ID) (cid.Cid, bool) {
-	v, ok := h.m.Load(p)
-	if !ok {
-		return cid.Undef, false
-	}
-	return v.(cid.Cid), true
 }
 
 // UseLatestSyncHandler sets the latest sync handler to use.

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -92,8 +92,8 @@ type Subscriber struct {
 	// transport.
 	httpPeerstore peerstore.Peerstore
 
-	idleHandlerTTL   time.Duration
-	latestSyncHander LatestSyncHandler
+	idleHandlerTTL    time.Duration
+	latestSyncHandler LatestSyncHandler
 
 	segDepthLimit int64
 
@@ -116,9 +116,8 @@ type SyncFinished struct {
 	// PeerID identifies the peer this SyncFinished event pertains to. This is
 	// the publisher of the advertisement chain.
 	PeerID peer.ID
-	// A list of cids that this sync acquired. In order from latest to oldest.
-	// The latest cid will always be at the beginning.
-	SyncedCids []cid.Cid
+	// Count is the number of CID synced.
+	Count int
 }
 
 // handler holds state that is specific to a peer
@@ -127,10 +126,9 @@ type handler struct {
 	// syncMutex serializes the handling of individual syncs. This should only
 	// guard the actual handling of a sync, nothing else.
 	syncMutex sync.Mutex
-	// If this sync will update the latestSync state (via latestSyncHandler) then
-	// it should grab this lock to insure no other process updates that state
-	// concurrently.
-	latestSyncMu sync.Mutex
+	// latestSync is the cid of the latest sync that Subscribe was told to
+	// remember. It is protected by syncMutex.
+	latestSync cid.Cid
 	// peerID is the ID of the peer this handler is responsible for. This is
 	// the publisher of an advertisement chain.
 	peerID peer.ID
@@ -159,7 +157,8 @@ func wrapBlockHook() (*sync.RWMutex, map[peer.ID]func(peer.ID, cid.Cid), func(pe
 	}
 }
 
-// NewSubscriber creates a new Subscriber that process pubsub messages.
+// NewSubscriber creates a new Subscriber that processes pubsub messages and
+// syncs dags advertised using the specified selector.
 func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, topic string, dss ipld.Node, options ...Option) (*Subscriber, error) {
 	opts, err := getOpts(options)
 	if err != nil {
@@ -185,11 +184,6 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 	httpPeerstore, err := pstoremem.NewPeerstore()
 	if err != nil {
 		return nil, err
-	}
-
-	latestSyncHandler := opts.latestSyncHandler
-	if latestSyncHandler == nil {
-		latestSyncHandler = &DefaultLatestSyncHandler{}
 	}
 
 	rcvr, err := announce.NewReceiver(host, topic,
@@ -222,13 +216,18 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 		scopedBlockHook:      scopedBlockHook,
 		generalBlockHook:     opts.blockHook,
 
-		idleHandlerTTL:   opts.idleHandlerTTL,
-		latestSyncHander: latestSyncHandler,
+		idleHandlerTTL:    opts.idleHandlerTTL,
+		latestSyncHandler: opts.latestSyncHandler,
 
 		segDepthLimit: opts.segDepthLimit,
 
 		receiver: rcvr,
 	}
+
+	if s.latestSyncHandler == nil {
+		s.latestSyncHandler = &DefaultLatestSyncHandler{}
+	}
+
 	// Start watcher to read announce messages.
 	go s.watch()
 	// Start distributor to send SyncFinished messages to interested parties.
@@ -249,11 +248,21 @@ func (s *Subscriber) HttpPeerStore() peerstore.Peerstore {
 // data is synced with that peer, it means that the Subscriber does not know
 // about it. Calling Sync() first may be necessary.
 func (s *Subscriber) GetLatestSync(peerID peer.ID) ipld.Link {
-	v, ok := s.latestSyncHander.GetLatestSync(peerID)
-	if !ok || v == cid.Undef {
-		return nil
+	hnd := s.getOrCreateHandler(peerID)
+	hnd.syncMutex.Lock()
+	defer hnd.syncMutex.Unlock()
+
+	if hnd.latestSync != cid.Undef {
+		return cidlink.Link{Cid: hnd.latestSync}
 	}
-	return cidlink.Link{Cid: v}
+
+	v, ok := s.latestSyncHandler.GetLatestSync(peerID)
+	if ok && v != cid.Undef {
+		hnd.latestSync = v
+		return cidlink.Link{Cid: v}
+	}
+
+	return nil
 }
 
 // SetLatestSync sets the latest synced CID for a specified peer. If there is
@@ -263,15 +272,12 @@ func (s *Subscriber) SetLatestSync(peerID peer.ID, latestSync cid.Cid) error {
 	if latestSync == cid.Undef {
 		return errors.New("cannot set latest sync to undefined value")
 	}
-	hnd, err := s.getOrCreateHandler(peerID)
-	if err != nil {
-		return err
-	}
+	hnd := s.getOrCreateHandler(peerID)
+	hnd.syncMutex.Lock()
+	defer hnd.syncMutex.Unlock()
 
-	hnd.latestSyncMu.Lock()
-	s.latestSyncHander.SetLatestSync(peerID, latestSync)
-	hnd.latestSyncMu.Unlock()
-
+	hnd.latestSync = latestSync
+	s.latestSyncHandler.SetLatestSync(peerID, latestSync)
 	return nil
 }
 
@@ -471,7 +477,8 @@ func (s *Subscriber) Sync(ctx context.Context, peerInfo peer.AddrInfo, nextCid c
 
 		log.Infow("Sync queried head CID", "cid", nextCid)
 		if sel == nil {
-			// Update the latestSync only if no CID and no selector given.
+			// Update the latestSync only if no CID (syncing ads) and no
+			// selector given.
 			updateLatest = true
 		}
 	}
@@ -494,21 +501,10 @@ func (s *Subscriber) Sync(ctx context.Context, peerInfo peer.AddrInfo, nextCid c
 
 	// Check for an existing handler for the specified peer (publisher). If
 	// none, create one if allowed.
-	hnd, err := s.getOrCreateHandler(peerInfo.ID)
-	if err != nil {
-		return cid.Undef, err
-	}
-
-	if updateLatest {
-		// Grab the latestSyncMu lock so that an async handler doesn't update
-		// the latestSync between when we call hnd.handle and when we actually
-		// updateLatest.
-		hnd.latestSyncMu.Lock()
-		defer hnd.latestSyncMu.Unlock()
-	}
+	hnd := s.getOrCreateHandler(peerInfo.ID)
 
 	hnd.syncMutex.Lock()
-	syncedCids, err := hnd.handle(ctx, nextCid, sel, wrapSel, syncer, opts.scopedBlockHook, opts.segDepthLimit)
+	syncCount, err := hnd.handle(ctx, nextCid, sel, wrapSel, syncer, opts.scopedBlockHook, opts.segDepthLimit)
 	hnd.syncMutex.Unlock()
 	if err != nil {
 		return cid.Undef, fmt.Errorf("sync handler failed: %w", err)
@@ -533,12 +529,7 @@ func (s *Subscriber) Sync(ctx context.Context, peerInfo peer.AddrInfo, nextCid c
 	}
 
 	if updateLatest {
-		s.latestSyncHander.SetLatestSync(peerInfo.ID, nextCid)
-		s.inEvents <- SyncFinished{
-			Cid:        nextCid,
-			PeerID:     peerInfo.ID,
-			SyncedCids: syncedCids,
-		}
+		hnd.sendSyncFinishedEvent(nextCid, syncCount)
 	}
 
 	return nextCid, nil
@@ -561,8 +552,22 @@ func (s *Subscriber) distributeEvents() {
 	}
 }
 
+// getHandler returns an existing handler for a specific peer
+func (s *Subscriber) getHandler(peerID peer.ID) *handler {
+	s.handlersMutex.Lock()
+	defer s.handlersMutex.Unlock()
+
+	// Check for existing handler, return if found.
+	hnd, ok := s.handlers[peerID]
+	if !ok {
+		return nil
+	}
+	hnd.expires = time.Now().Add(s.idleHandlerTTL)
+	return hnd
+}
+
 // getOrCreateHandler creates a handler for a specific peer
-func (s *Subscriber) getOrCreateHandler(peerID peer.ID) (*handler, error) {
+func (s *Subscriber) getOrCreateHandler(peerID peer.ID) *handler {
 	expires := time.Now().Add(s.idleHandlerTTL)
 
 	s.handlersMutex.Lock()
@@ -581,7 +586,7 @@ func (s *Subscriber) getOrCreateHandler(peerID peer.ID) (*handler, error) {
 		s.handlers[peerID] = hnd
 	}
 
-	return hnd, nil
+	return hnd
 }
 
 // idleHandlerCleaner periodically looks for idle handlers to remove. This
@@ -625,11 +630,7 @@ func (s *Subscriber) watch() {
 			break
 		}
 
-		hnd, err := s.getOrCreateHandler(amsg.PeerID)
-		if err != nil {
-			log.Errorw("Cannot create handler for announce", "err", err)
-			continue
-		}
+		hnd := s.getOrCreateHandler(amsg.PeerID)
 
 		peerInfo := peer.AddrInfo{
 			ID:    amsg.PeerID,
@@ -708,8 +709,8 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, syncer Synce
 
 			// Wait for any other goroutine, for this handler, to finish
 			// updating the latest sync.
-			h.latestSyncMu.Lock()
-			defer h.latestSyncMu.Unlock()
+			h.syncMutex.Lock()
+			defer h.syncMutex.Unlock()
 
 			if ctx.Err() != nil {
 				log.Warnw("Abandoned pending sync", "err", ctx.Err(), "publisher", h.peerID)
@@ -724,19 +725,14 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, syncer Synce
 			h.pendingSyncer = nil
 			h.qlock.Unlock()
 
-			h.syncMutex.Lock()
-			syncedCids, err := h.handle(ctx, c, h.subscriber.dss, true, syncer, h.subscriber.generalBlockHook, h.subscriber.segDepthLimit)
-			h.syncMutex.Unlock()
+			syncCount, err := h.handle(ctx, c, h.subscriber.dss, true, syncer, h.subscriber.generalBlockHook, h.subscriber.segDepthLimit)
 			if err != nil {
 				// Failed to handle the sync, so allow another announce for the same CID.
 				h.subscriber.receiver.UncacheCid(c)
 				log.Errorw("Cannot process message", "err", err, "publisher", h.peerID)
 				return
 			}
-
-			// Update latest head seen.
-			h.subscriber.latestSyncHander.SetLatestSync(h.peerID, c)
-			h.subscriber.inEvents <- SyncFinished{Cid: c, PeerID: h.peerID, SyncedCids: syncedCids}
+			h.sendSyncFinishedEvent(c, syncCount)
 		}()
 	} else {
 		log.Infow("Pending announce replaced by new", "previous_cid", h.pendingCid, "new_cid", nextCid, "publisher", h.peerID)
@@ -806,15 +802,30 @@ func (ss *segmentedSync) reset() {
 	ss.err = nil
 }
 
+func (h *handler) sendSyncFinishedEvent(c cid.Cid, count int) {
+	h.latestSync = c
+	h.subscriber.latestSyncHandler.SetLatestSync(h.peerID, c)
+	h.subscriber.inEvents <- SyncFinished{
+		Cid:    c,
+		PeerID: h.peerID,
+		Count:  count,
+	}
+}
+
 // handle processes a message from the peer that the handler is responsible for.
-func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel bool, syncer Syncer, bh BlockHookFunc, segdl int64) ([]cid.Cid, error) {
+func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel bool, syncer Syncer, bh BlockHookFunc, segdl int64) (int, error) {
 	log := log.With("cid", nextCid, "peer", h.peerID)
 
 	if wrapSel {
 		var latestSyncLink ipld.Link
-		latestSync, ok := h.subscriber.latestSyncHander.GetLatestSync(h.peerID)
-		if ok && latestSync != cid.Undef {
-			latestSyncLink = cidlink.Link{Cid: latestSync}
+		if h.latestSync == cid.Undef {
+			latestSync, ok := h.subscriber.latestSyncHandler.GetLatestSync(h.peerID)
+			if ok && latestSync != cid.Undef {
+				h.latestSync = latestSync
+				latestSyncLink = cidlink.Link{Cid: latestSync}
+			}
+		} else {
+			latestSyncLink = cidlink.Link{Cid: h.latestSync}
 		}
 		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, latestSyncLink)
 	}
@@ -822,16 +833,16 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 	stopNode, stopNodeOK := getStopNode(sel)
 	if stopNodeOK && stopNode.(cidlink.Link).Cid == nextCid {
 		log.Infow("cid to sync to is the stop node. Nothing to do")
-		return nil, nil
+		return 0, nil
 	}
 
 	segSync := &segmentedSync{
 		nextSyncCid: &nextCid,
 	}
 
-	var syncedCids []cid.Cid
+	var syncedCount int
 	hook := func(p peer.ID, c cid.Cid) {
-		syncedCids = append(syncedCids, c)
+		syncedCount++
 		if bh != nil {
 			bh(p, c, segSync)
 		}
@@ -878,10 +889,10 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 	if !syncBySegment {
 		err := syncer.Sync(ctx, nextCid, sel)
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
-		log.Infow("Non-segmented sync completed", "syncedCidCount", len(syncedCids))
-		return syncedCids, nil
+		log.Infow("Non-segmented sync completed", "syncedCount", syncedCount)
+		return syncedCount, nil
 	}
 
 	var nextDepth = segdl
@@ -893,18 +904,18 @@ SegSyncLoop:
 		if !ok {
 			// This should not happen if we were able to extract origLimit from
 			// sel. If this happens there is likely a bug. Fail fast.
-			return nil, fmt.Errorf("failed to construct segment selector with recursion depth limit of %d", nextDepth)
+			return 0, fmt.Errorf("failed to construct segment selector with recursion depth limit of %d", nextDepth)
 		}
 		nextCid = *segSync.nextSyncCid
 		segSync.reset()
 		err := syncer.Sync(ctx, nextCid, segmentSel)
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
 		depthSoFar += nextDepth
 
 		if segSync.err != nil {
-			return nil, segSync.err
+			return 0, segSync.err
 		}
 
 		// If hook action is not called, or next CID is set to cid.Undef then break out of the
@@ -931,10 +942,10 @@ SegSyncLoop:
 				nextDepth = remainingDepth
 			}
 		default:
-			return nil, fmt.Errorf("unknown recursion limit mode: %v", origLimit.Mode())
+			return 0, fmt.Errorf("unknown recursion limit mode: %v", origLimit.Mode())
 		}
 	}
 
-	log.Infow("Segmented sync completed", "syncedCidCount", len(syncedCids))
-	return syncedCids, nil
+	log.Infow("Segmented sync completed", "syncedCount", syncedCount)
+	return syncedCount, nil
 }

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -534,20 +534,6 @@ func (s *Subscriber) distributeEvents() {
 	}
 }
 
-// getHandler returns an existing handler for a specific peer
-func (s *Subscriber) getHandler(peerID peer.ID) *handler {
-	s.handlersMutex.Lock()
-	defer s.handlersMutex.Unlock()
-
-	// Check for existing handler, return if found.
-	hnd, ok := s.handlers[peerID]
-	if !ok {
-		return nil
-	}
-	hnd.expires = time.Now().Add(s.idleHandlerTTL)
-	return hnd
-}
-
 // getOrCreateHandler creates a handler for a specific peer
 func (s *Subscriber) getOrCreateHandler(peerID peer.ID) *handler {
 	expires := time.Now().Add(s.idleHandlerTTL)

--- a/dagsync/subscriber_test.go
+++ b/dagsync/subscriber_test.go
@@ -146,10 +146,10 @@ func TestSyncedCidsReturned(t *testing.T) {
 			require.NoError(t, err)
 
 			finishedVal := <-onFinished
-			require.Equalf(t, int(ll.Length), len(finishedVal.SyncedCids),
-				"The finished value should include %d synced cids, but has %d", ll.Length, len(finishedVal.SyncedCids))
+			require.Equalf(t, int(ll.Length), finishedVal.Count,
+				"The finished value should include %d synced cids, but has %d", ll.Length, finishedVal.Count)
 
-			require.Equal(t, head.(cidlink.Link).Cid, finishedVal.SyncedCids[0],
+			require.Equal(t, head.(cidlink.Link).Cid, finishedVal.Cid,
 				"The latest synced cid should be the head and first in the list")
 		})
 	}, &quick.Config{
@@ -593,6 +593,8 @@ func TestBackpressureDoesntDeadlock(t *testing.T) {
 		// sync a user will call explicitly, so it should not be blocked by the
 		// backpressure of SyncFinishedEvent (it doesn't emit a SyncFinishedEvent).
 		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for sync to finish")
 	}
 
 	// Now pull from onSyncFinishedChan


### PR DESCRIPTION
## Problem
The package go-libipni/dagsync has some issues surrounding setting and getting the latest sync, because it conflates the ideas of last ad _synced_ and last ad _processed_. It uses this to cause different behavious when syncing an ad chain or an entry chain.

- SyncFinished event is only sent if updating the latest sync, which is what differentiates syncing an ad chain from an entry chain or syncing an ad chain using a selector.
- There is logic and synchronization in dagsync around updating the latest sync, which amounts to no-op because of the latest sync handler set up by storetheindex.
- When dagsync gets the latest sync via the sync handler supplied by storetheindex, it gets the latest ad _processed_, not the latest ad already _synced_. 

This comment from `SetLatestSync` [here](https://github.com/ipni/storetheindex/blob/main/internal/ingest/synchandler.go#L13-L16) states:
```go
// NOOP We don't care what dagsync tells us about its latest sync, we are
// using the latestSync mechanism to traverse to the last processed Ad.
// This means that the only thing that sets our notion of latest sync is
// marking an ad as processed.
```
One of the reasons for this is to make the sync of the ad chain generate a SyncFinished event that has all the CIDs in the chain back to the last ad _processed_, to allow storetheindex to iterate these and process all unprocessed ads.

Unfortunately, this means that unprocessed ads can be repeatedly synced because dagsync does not know it has already synced those ads (since they are not _processed_ yet). This happens if an announcement arrives before processing ads have finished or if processing ads failed. Since the ad data is already on the indexer, it may not actually be fetched from the publisher but still must be iterated during the ad sync, and all the already-synced CIDs are added to the SyncFinished event.

Similar is true when performing a manual sync, which is not a resync, when the ads are already synced but not processed and the stop node is set to the latest _processed_ ad CID.

## Fix
The redundant syncs of unprocessed portions of ad chains can be fixed by having dagsync track the last ad _synced_, and only asking the storetheindex for the last ad processed if it does not know the last ad synced. Additionally, the SyncFinished event should only return the latest CID synced, and storetheindex should iterate unprocessed ads by loading each ad from the datastore and then getting the CID of the next ad to load.

By only returning the latest ad synced and having STI iterate using ad links, dagsync only needs to sync the _unsynced_ portion of the chain since it does not have to return a list of _unprocessed_ ads. This will also fix the large memory consumption problem when ad chains are millions of ads long because the SyncFinished event will not need to carry a slice of millions of CIDs

This will allow dagsync to work more like it was originally intended: to keep the dag (ad chain) in sync between a producer and consumer, without depending on domain-specific processing that the consumer (storetheindex) may do on that dag.

In other words, dagsync can incrementally keep ad chains in sync, independent of storetheindex. Dagsync will inform storetheindex know when it has gotten farther along in an ad chain sync so that storetheindex can process those ads.

### Implementation of Fix
- dagsync will track the latest synced CID (of advertisement chain)
    - gets the latest processed ad only when it does not know the latest synced ad
- SyncFinished event does not contain a slice of synced CIDs, only the latest
- storetheindex iterates ads from SyncFinished event by looking at links in each ad
- storetheindex does not supply an alternate latest sync handler to dagsync
    - supplies function to look up stored latest sync
    - anyone that needs to get the latest synced cid from dagsync can use the SyncFinished event since the latest sync handler `SetLatestSync` is completely redundant to this. 
