### PR TITLE
Provider last error

### DIFF
--- a/find/model/provider_info.go
+++ b/find/model/provider_info.go
@@ -38,6 +38,11 @@ type ProviderInfo struct {
 	// Inactive means that no update has been received for the configured
 	// Discovery.PollInterval, and the publisher is not responding to polls.
 	Inactive bool `json:",omitempty"`
+	// LastError is a description of the last ingestion error to occur for this
+	// provider.
+	LastError string `json:",omitempty"`
+	// LastErrorTime is the time that LastError occurred.
+	LastErrorTime string `json:",omitempty"`
 }
 
 // ExtendedProviders contains chain-level and context-level extended provider


### PR DESCRIPTION
- Include last error in provider info
- Generate error event when async sync of ad chain fails.