### PR TITLE
DHClient can have a dhstore URL or API 

### DIFF
--- a/find/client/dhash_client.go
+++ b/find/client/dhash_client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -30,7 +29,6 @@ type DHStoreAPI interface {
 }
 
 type DHashClient struct {
-	c          *http.Client
 	dhstoreAPI DHStoreAPI
 	pcache     *providerCache
 }

--- a/find/client/dhstore_http.go
+++ b/find/client/dhstore_http.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/ipni/go-libipni/apierror"
+	"github.com/ipni/go-libipni/dhash"
+	"github.com/ipni/go-libipni/find/model"
+	b58 "github.com/mr-tron/base58/base58"
+	"github.com/multiformats/go-multihash"
+)
+
+type dhstoreHTTP struct {
+	c             *http.Client
+	dhFindURL     *url.URL
+	dhMetadataURL *url.URL
+}
+
+func (d *dhstoreHTTP) FindMultihash(ctx context.Context, dhmh multihash.Multihash) ([]model.EncryptedMultihashResult, error) {
+	u := d.dhFindURL.JoinPath(dhmh.B58String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := d.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, apierror.FromResponse(resp.StatusCode, body)
+	}
+
+	encResponse := &model.FindResponse{}
+	err = json.Unmarshal(body, encResponse)
+	if err != nil {
+		return nil, err
+	}
+	return encResponse.EncryptedMultihashResults, nil
+}
+
+func (d *dhstoreHTTP) FindMetadata(ctx context.Context, vk []byte) ([]byte, error) {
+	u := d.dhMetadataURL.JoinPath(b58.Encode(dhash.SHA256(vk, nil)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := d.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, apierror.FromResponse(resp.StatusCode, body)
+	}
+
+	type GetMetadataResponse struct {
+		EncryptedMetadata []byte `json:"EncryptedMetadata"`
+	}
+
+	findResponse := &GetMetadataResponse{}
+	err = json.Unmarshal(body, findResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return findResponse.EncryptedMetadata, nil
+}

--- a/find/client/option.go
+++ b/find/client/option.go
@@ -8,6 +8,7 @@ import (
 type config struct {
 	httpClient *http.Client
 	dhstoreURL string
+	dhstoreAPI DHStoreAPI
 }
 
 // Option is a function that sets a value in a config.
@@ -43,6 +44,16 @@ func WithClient(c *http.Client) Option {
 func WithDHStoreURL(u string) Option {
 	return func(cfg *config) error {
 		cfg.dhstoreURL = u
+		return nil
+	}
+}
+
+// WithDHStoreAPI configures an interface to use for doing multihash and
+// metadata lookups with dhstore. If this is not configured, then dhstore
+// lookups are done using the dhstoreURL.
+func WithDHStoreAPI(dhsAPI DHStoreAPI) Option {
+	return func(cfg *config) error {
+		cfg.dhstoreAPI = dhsAPI
 		return nil
 	}
 }


### PR DESCRIPTION
DHashClient can be given a dhstore API interface when the client within dhstore, This is so that dhstore can give it a set of internal functions to call to do dh multihash and metadata lookups. Otherwise, a client that is not in dhstore uses the dhstore URL to perfrom remote dhstore lookups.