### PR TITLE
Log provider not found error correctly.

### DIFF
--- a/pcache/http_source.go
+++ b/pcache/http_source.go
@@ -74,6 +74,9 @@ func (s *httpSource) Fetch(ctx context.Context, pid peer.ID) (*model.ProviderInf
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode != http.StatusNotFound {
+			return nil, nil
+		}
 		return nil, apierror.FromResponse(resp.StatusCode, body)
 	}
 
@@ -121,4 +124,8 @@ func (s *httpSource) FetchAll(ctx context.Context) ([]*model.ProviderInfo, error
 		return nil, err
 	}
 	return providers, nil
+}
+
+func (s *httpSource) String() string {
+	return s.url.String()
 }

--- a/pcache/provider_cache_test.go
+++ b/pcache/provider_cache_test.go
@@ -77,6 +77,10 @@ func (s *mockSource) FetchAll(ctx context.Context) ([]*model.ProviderInfo, error
 	return s.infos, nil
 }
 
+func (s *mockSource) String() string {
+	return "mockSource"
+}
+
 func TestProviderCache(t *testing.T) {
 	src := newMockSource(pid1)
 	pc, err := pcache.New(pcache.WithSource(src))


### PR DESCRIPTION
- Do not log when provider not found a individual source, as this is normal when there are multiple sources.
- Log when provider not found an any source.