### PR TITLE
Remove IndexCount from provider information

### DIFF
--- a/find/client/client.go
+++ b/find/client/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/ipni/go-libipni/apierror"
 	"github.com/ipni/go-libipni/find/model"
@@ -40,13 +39,12 @@ func New(baseURL string, options ...Option) (*Client, error) {
 		return nil, err
 	}
 
-	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
-		baseURL = "http://" + baseURL
-	}
-
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("url must have http or https scheme: %s", baseURL)
 	}
 	u.Path = ""
 

--- a/find/client/dhash_client.go
+++ b/find/client/dhash_client.go
@@ -3,8 +3,8 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
-	"strings"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipni/go-libipni/dhash"
@@ -71,9 +71,12 @@ func NewDHashClient(options ...Option) (*DHashClient, error) {
 		if opts.dhstoreURL == "" {
 			opts.dhstoreURL = opts.providersURLs[0]
 		}
-		dhsURL, err = parseURL(opts.dhstoreURL)
+		dhsURL, err = url.Parse(opts.dhstoreURL)
 		if err != nil {
 			return nil, err
+		}
+		if dhsURL.Scheme != "http" && dhsURL.Scheme != "https" {
+			return nil, fmt.Errorf("url must have http or https scheme: %s", opts.dhstoreURL)
 		}
 		dhsAPI = &dhstoreHTTP{
 			c:             opts.httpClient,
@@ -182,11 +185,4 @@ func (c *DHashClient) fetchMetadata(ctx context.Context, vk []byte) ([]byte, err
 		return nil, err
 	}
 	return dhash.DecryptMetadata(encryptedMetadata, vk)
-}
-
-func parseURL(su string) (*url.URL, error) {
-	if !strings.HasPrefix(su, "http://") && !strings.HasPrefix(su, "https://") {
-		su = "http://" + su
-	}
-	return url.Parse(su)
 }

--- a/find/model/provider_info.go
+++ b/find/model/provider_info.go
@@ -24,9 +24,6 @@ type ProviderInfo struct {
 	// provider's advertisement publisher. Content advertisements are available
 	// at these addresses.
 	Publisher *peer.AddrInfo `json:",omitempty"`
-	// IndexCount is the number of current (not deleted) indexes that the
-	// indexer knowns about for this provider.
-	IndexCount uint64 `json:",omitempty"`
 	// ExtendedProviders describes extended providers registered for this
 	// provider.
 	ExtendedProviders *ExtendedProviders `json:",omitempty"`

--- a/ingest/client/client.go
+++ b/ingest/client/client.go
@@ -3,10 +3,10 @@ package client
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipni/go-libipni/announce/message"
@@ -42,13 +42,12 @@ func New(baseURL string, options ...Option) (*Client, error) {
 		return nil, err
 	}
 
-	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
-		baseURL = "http://" + baseURL
-	}
-
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("url must have http or https scheme: %s", baseURL)
 	}
 	u.Path = ""
 

--- a/pcache/http_source.go
+++ b/pcache/http_source.go
@@ -3,7 +3,7 @@ package pcache
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -27,7 +27,7 @@ func NewHTTPSource(srcURL string, client *http.Client) (ProviderSource, error) {
 		return nil, err
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return nil, errors.New("url must have http or https scheme")
+		return nil, fmt.Errorf("url must have http or https scheme: %s", srcURL)
 	}
 	u.Path = ""
 	u = u.JoinPath(providersPath)


### PR DESCRIPTION
- Indexers no longer include `IndexCount` in provider information
- If a URL does not have `http` or `https` scheme, return error.