### PR TITLE
Do not add extra newline after streaming json response

### DIFF
--- a/rwriter/provider_response_writer.go
+++ b/rwriter/provider_response_writer.go
@@ -28,9 +28,7 @@ func (pw *ProviderResponseWriter) WriteProviderResult(pr model.ProviderResult) e
 		if err != nil {
 			return err
 		}
-		if err = pw.WriteND(); err != nil {
-			return err
-		}
+		pw.Flush()
 	} else {
 		pw.result.ProviderResults = append(pw.result.ProviderResults, pr)
 	}

--- a/rwriter/response_writer.go
+++ b/rwriter/response_writer.go
@@ -144,15 +144,10 @@ func (w *ResponseWriter) PathType() string {
 	return w.pathType
 }
 
-func (w *ResponseWriter) WriteND() error {
-	_, err := w.w.Write([]byte("\n"))
-	if err != nil {
-		return err
-	}
+func (w *ResponseWriter) Flush() {
 	if w.f != nil {
 		w.f.Flush()
 	}
-	return nil
 }
 
 func (w *ResponseWriter) Cid() cid.Cid {


### PR DESCRIPTION
json.Encoder.Encode already adds a newline after each record:
https://pkg.go.dev/encoding/json#Encoder.Encode