### PR TITLE
Having `announce.Receiver` is optional for `Subscriber`

### DIFF
--- a/announce/option.go
+++ b/announce/option.go
@@ -29,7 +29,7 @@ func getOpts(opts []Option) (config, error) {
 }
 
 // WithAllowPeer sets the function that determines whether to allow or reject
-// messages from a peer.
+// messages from a peer. When not set or nil, allows messages from all peers.
 func WithAllowPeer(allowPeer AllowPeerFunc) Option {
 	return func(c *config) error {
 		c.allowPeer = allowPeer

--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipni/go-libipni/announce"
 	"github.com/ipni/go-libipni/dagsync/dtsync"
 	"github.com/ipni/go-libipni/dagsync/httpsync"
 	"github.com/ipni/go-libipni/dagsync/test"
@@ -40,7 +41,7 @@ func TestAnnounceReplace(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
-	sub, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
+	sub, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, RecvAnnounce())
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -163,7 +164,7 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 	defer pubh.Close()
 	subds := dssync.MutexWrap(datastore.NewMapDatastore())
 	subls := test.MkLinkSystem(subds)
-	sub, err := NewSubscriber(subh, subds, subls, testTopic, nil)
+	sub, err := NewSubscriber(subh, subds, subls, testTopic, RecvAnnounce())
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -217,11 +218,13 @@ func TestAnnounceRepublish(t *testing.T) {
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, dstHost, dstHost2)
 
-	sub2, err := NewSubscriber(dstHost2, dstStore2, dstLnkS2, testTopic, nil, Topic(topics[1]))
+	sub2, err := NewSubscriber(dstHost2, dstStore2, dstLnkS2, testTopic,
+		RecvAnnounce(announce.WithTopic(topics[1])))
 	require.NoError(t, err)
 	defer sub2.Close()
 
-	sub1, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, Topic(topics[0]), ResendAnnounce(true))
+	sub1, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic,
+		RecvAnnounce(announce.WithTopic(topics[0]), announce.WithResend(true)))
 	require.NoError(t, err)
 	defer sub1.Close()
 

--- a/dagsync/http_test.go
+++ b/dagsync/http_test.go
@@ -49,7 +49,7 @@ func setupPublisherSubscriber(t *testing.T, subscriberOptions []dagsync.Option) 
 	dstLinkSys := test.MkLinkSystem(dstStore)
 	dstHost := test.MkTestHost()
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLinkSys, testTopic, nil, subscriberOptions...)
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLinkSys, testTopic, subscriberOptions...)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		sub.Close()

--- a/dagsync/sync_test.go
+++ b/dagsync/sync_test.go
@@ -44,7 +44,7 @@ func TestLatestSyncSuccess(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.RecvAnnounce(announce.WithTopic(topics[1])))
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -94,7 +94,8 @@ func TestSyncFn(t *testing.T) {
 		blocksSeenByHook[c] = struct{}{}
 	}
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]), dagsync.BlockHook(blockHook))
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.BlockHook(blockHook),
+		dagsync.RecvAnnounce(announce.WithTopic(topics[1])))
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -208,7 +209,7 @@ func TestPartialSync(t *testing.T) {
 	defer pub.Close()
 	test.MkChain(srcLnkS, true)
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.RecvAnnounce(announce.WithTopic(topics[1])))
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -267,7 +268,7 @@ func TestStepByStepSync(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.RecvAnnounce(announce.WithTopic(topics[1])))
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -312,7 +313,7 @@ func TestLatestSyncFailure(t *testing.T) {
 	t.Log("source host:", srcHost.ID())
 	t.Log("targer host:", dstHost.ID())
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.RecvAnnounce())
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -333,7 +334,7 @@ func TestLatestSyncFailure(t *testing.T) {
 	sub.Close()
 
 	dstStore = dssync.MutexWrap(datastore.NewMapDatastore())
-	sub2, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
+	sub2, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic)
 	require.NoError(t, err)
 	defer sub2.Close()
 
@@ -364,7 +365,7 @@ func TestAnnounce(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.RecvAnnounce())
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -401,7 +402,7 @@ func TestCancelDeadlock(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic)
 	require.NoError(t, err)
 	defer sub.Close()
 


### PR DESCRIPTION
It is not always necessary to have an announcement receiver driving the Subscriber, such as when it is used within a CLI to get advertisements on-demand only. Making it optional avoids the setup time and possible unwanted automated behaviors that result from having the announcement receiver enabled.