### PR TITLE
Need to register Raw codec to support cid.Raw

### DIFF
--- a/ingest/schema/schema.go
+++ b/ingest/schema/schema.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
+	_ "github.com/ipld/go-ipld-prime/codec/raw"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/schema"

--- a/ingest/schema/types_test.go
+++ b/ingest/schema/types_test.go
@@ -256,6 +256,16 @@ func Test_MismatchingNodeIsError(t *testing.T) {
 	require.True(t, strings.HasPrefix(err.Error(), "faild to convert node prototype"))
 }
 
+func Test_LinkLoadNoEntries(t *testing.T) {
+	ls := cidlink.DefaultLinkSystem()
+	store := &memstore.Store{}
+	ls.SetReadStorage(store)
+	ls.SetWriteStorage(store)
+
+	_, err := ls.Load(ipld.LinkContext{}, stischema.NoEntries, stischema.AdvertisementPrototype)
+	require.Equal(t, "404", err.Error())
+}
+
 func generateAdvertisement() *stischema.Advertisement {
 	mhs := test.RandomMultihashes(7)
 	prev := ipld.Link(cidlink.Link{Cid: cid.NewCidV1(cid.Raw, mhs[0])})


### PR DESCRIPTION
The Raw codec was previously registered by other packages used in projects that depended on go-libipni, so the problem was not previously seen. Now that the codec is not registered by those packages, projects using go-libipni fail with the error:
```
could not choose a decoder: no decoder registered for multicodec code 85 (0x55)
```
when encountering advertisements with CIDs that use `cid.Raw`.  Registering the Raw codec fixes this.