### PR TITLE
Log addresses that are in announce messages

### DIFF
--- a/announce/receiver.go
+++ b/announce/receiver.go
@@ -276,9 +276,9 @@ func (r *Receiver) watch(ctx context.Context) {
 				log.Errorw("Cannot read peerID from republished announce", "err", err)
 				continue
 			}
-			log.Infow("Handling re-published pubsub announce", "originPeer", srcPeer, "relayPeer", relayPeer)
+			log.Infow("Handling re-published pubsub announce", "originPeer", srcPeer, "relayPeer", relayPeer, "addrs", addrs)
 		} else {
-			log.Infow("Handling pubsub announce", "peer", srcPeer)
+			log.Infow("Handling pubsub announce", "peer", srcPeer, "addrs", addrs)
 		}
 
 		amsg := Announce{
@@ -305,7 +305,7 @@ func (r *Receiver) watch(ctx context.Context) {
 // publisher, since an announce message announces the availability of an
 // advertisement and where to retrieve it from.
 func (r *Receiver) Direct(ctx context.Context, nextCid cid.Cid, peerID peer.ID, addrs []multiaddr.Multiaddr) error {
-	log.Infow("Handling direct announce", "peer", peerID)
+	log.Infow("Handling direct announce", "peer", peerID, "addrs", addrs)
 	amsg := Announce{
 		Cid:    nextCid,
 		PeerID: peerID,

--- a/announce/receiver_test.go
+++ b/announce/receiver_test.go
@@ -53,6 +53,7 @@ func init() {
 
 func TestReceiverBasic(t *testing.T) {
 	srcHost, _ := libp2p.New()
+	t.Cleanup(func() { srcHost.Close() })
 	rcvr, err := announce.NewReceiver(srcHost, testTopic)
 	require.NoError(t, err)
 
@@ -68,6 +69,7 @@ func TestReceiverBasic(t *testing.T) {
 
 func TestReceiverCloseWaitingNext(t *testing.T) {
 	srcHost, _ := libp2p.New()
+	t.Cleanup(func() { srcHost.Close() })
 	rcvr, err := announce.NewReceiver(srcHost, testTopic)
 	require.NoError(t, err)
 
@@ -91,6 +93,7 @@ func TestReceiverCloseWaitingNext(t *testing.T) {
 
 func TestReceiverCloseWaitingDirect(t *testing.T) {
 	srcHost, _ := libp2p.New()
+	t.Cleanup(func() { srcHost.Close() })
 	rcvr, err := announce.NewReceiver(srcHost, testTopic)
 	require.NoError(t, err)
 
@@ -117,6 +120,7 @@ func TestReceiverCloseWaitingDirect(t *testing.T) {
 
 func TestReceiverCidCache(t *testing.T) {
 	srcHost, _ := libp2p.New()
+	t.Cleanup(func() { srcHost.Close() })
 	rcvr, err := announce.NewReceiver(srcHost, testTopic)
 	require.NoError(t, err)
 

--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -28,10 +28,9 @@ func TestAnnounceReplace(t *testing.T) {
 	t.Parallel()
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
-
-	dstHost := test.MkTestHost()
+	dstHost := test.MkTestHost(t)
 
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
@@ -139,8 +138,7 @@ func TestAnnounceReplace(t *testing.T) {
 
 func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 	// Instantiate a HTTP publisher
-	pubh := test.MkTestHost()
-	defer pubh.Close()
+	pubh := test.MkTestHost(t)
 	pubds := dssync.MutexWrap(datastore.NewMapDatastore())
 	publs := test.MkLinkSystem(pubds)
 	pub, err := httpsync.NewPublisher("0.0.0.0:0", publs, pubh.Peerstore().PrivKey(pubh.ID()))
@@ -160,8 +158,7 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 	anotherC := anotherLink.(cidlink.Link).Cid
 
 	// Instantiate a subscriber
-	subh := test.MkTestHost()
-	defer pubh.Close()
+	subh := test.MkTestHost(t)
 	subds := dssync.MutexWrap(datastore.NewMapDatastore())
 	subls := test.MkLinkSystem(subds)
 	sub, err := NewSubscriber(subh, subds, subls, testTopic, RecvAnnounce())
@@ -203,10 +200,9 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 func TestAnnounceRepublish(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
-
-	dstHost := test.MkTestHost()
+	dstHost := test.MkTestHost(t)
 
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
@@ -214,7 +210,7 @@ func TestAnnounceRepublish(t *testing.T) {
 
 	dstStore2 := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstLnkS2 := test.MkLinkSystem(dstStore2)
-	dstHost2 := test.MkTestHost()
+	dstHost2 := test.MkTestHost(t)
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, dstHost, dstHost2)
 

--- a/dagsync/dtsync/syncer_test.go
+++ b/dagsync/dtsync/syncer_test.go
@@ -60,13 +60,14 @@ func TestDTSync_CallsBlockHookWhenCIDsAreFullyFoundLocally(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a publisher to sync from.
-	pubh := test.MkTestHost()
+	pubh := test.MkTestHost(t)
 	pub, err := dtsync.NewPublisher(pubh, dssync.MutexWrap(datastore.NewMapDatastore()), ls, topic)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, pub.Close()) })
 
 	// Set up a syncer.
-	subh := test.MkTestHost()
+	subh := test.MkTestHost(t)
+
 	subh.Peerstore().AddAddrs(pubh.ID(), pubh.Addrs(), peerstore.PermanentAddrTTL)
 	var gotCids []cid.Cid
 	testHook := func(id peer.ID, cid cid.Cid) {
@@ -140,7 +141,7 @@ func TestDTSync_CallsBlockHookWhenCIDsArePartiallyFoundLocally(t *testing.T) {
 		}
 
 		// Start a publisher to sync from.
-		pubh = test.MkTestHost()
+		pubh = test.MkTestHost(t)
 		pub, err := dtsync.NewPublisher(pubh, dssync.MutexWrap(datastore.NewMapDatastore()), publs, topic)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, pub.Close()) })
@@ -150,7 +151,7 @@ func TestDTSync_CallsBlockHookWhenCIDsArePartiallyFoundLocally(t *testing.T) {
 	}
 
 	// Set up a syncer.
-	subh := test.MkTestHost()
+	subh := test.MkTestHost(t)
 	subh.Peerstore().AddAddrs(pubh.ID(), pubh.Addrs(), peerstore.PermanentAddrTTL)
 	var gotCids []cid.Cid
 	testHook := func(id peer.ID, cid cid.Cid) {

--- a/dagsync/dtsync/util_test.go
+++ b/dagsync/dtsync/util_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func Test_registerVoucherHandlesAlreadyRegisteredGracefully(t *testing.T) {
-	h := test.MkTestHost()
-
+	h := test.MkTestHost(t)
 	dt, _, close, err := makeDataTransfer(h, datastore.NewMapDatastore(), cidlink.DefaultLinkSystem(), nil, 0, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, close()) })

--- a/dagsync/example_test.go
+++ b/dagsync/example_test.go
@@ -27,6 +27,7 @@ func ExamplePublisher() {
 	// Init dagsync publisher and subscriber.
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcHost, _ = libp2p.New()
+	defer srcHost.Close()
 	srcLnkS := makeLinkSystem(srcStore)
 
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
@@ -56,6 +57,7 @@ func ExamplePublisher() {
 
 func ExampleSubscriber() {
 	dstHost, _ := libp2p.New()
+	defer dstHost.Close()
 
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstLnkSys := makeLinkSystem(dstStore)

--- a/dagsync/http_test.go
+++ b/dagsync/http_test.go
@@ -36,9 +36,10 @@ func setupPublisherSubscriber(t *testing.T, subscriberOptions []dagsync.Option) 
 	srcPrivKey, _, err := ic.GenerateECDSAKeyPair(rand.Reader)
 	require.NoError(t, err, "Err generating private key")
 
-	srcHost = test.MkTestHost(libp2p.Identity(srcPrivKey))
+	srcHost = test.MkTestHost(t, libp2p.Identity(srcPrivKey))
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcLinkSys := test.MkLinkSystem(srcStore)
+
 	pub, err := httpsync.NewPublisher("127.0.0.1:0", srcLinkSys, srcPrivKey)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -47,7 +48,7 @@ func setupPublisherSubscriber(t *testing.T, subscriberOptions []dagsync.Option) 
 
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstLinkSys := test.MkLinkSystem(dstStore)
-	dstHost := test.MkTestHost()
+	dstHost := test.MkTestHost(t)
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLinkSys, testTopic, subscriberOptions...)
 	require.NoError(t, err)

--- a/dagsync/legs_test.go
+++ b/dagsync/legs_test.go
@@ -37,8 +37,8 @@ func TestMain(m *testing.M) {
 }
 
 func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching, allowPeer func(peer.ID) bool) (host.Host, host.Host, dagsync.Publisher, *dagsync.Subscriber, announce.Sender) {
-	srcHost := test.MkTestHost()
-	dstHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
+	dstHost := test.MkTestHost(t)
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -144,10 +144,8 @@ func TestPublisherRejectsPeer(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 
-	srcHost := test.MkTestHost()
-	dstHost := test.MkTestHost()
-	defer srcHost.Close()
-	defer dstHost.Close()
+	srcHost := test.MkTestHost(t)
+	dstHost := test.MkTestHost(t)
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 

--- a/dagsync/p2p/protocol/head/head_test.go
+++ b/dagsync/p2p/protocol/head/head_test.go
@@ -25,8 +25,8 @@ const testTopic = "/testtopic"
 func TestFetchLatestHead(t *testing.T) {
 	const ipPrefix = "/ip4/127.0.0.1/tcp/"
 
-	publisher := test.MkTestHost()
-	client := test.MkTestHost()
+	publisher := test.MkTestHost(t)
+	client := test.MkTestHost(t)
 
 	var addrs []multiaddr.Multiaddr
 	for _, a := range publisher.Addrs() {
@@ -73,8 +73,8 @@ func TestFetchLatestHead(t *testing.T) {
 }
 
 func TestOldProtocolID(t *testing.T) {
-	publisher := test.MkTestHost()
-	client := test.MkTestHost()
+	publisher := test.MkTestHost(t)
+	client := test.MkTestHost(t)
 
 	// Provide multiaddrs to connect to
 	client.Peerstore().AddAddrs(publisher.ID(), publisher.Addrs(), time.Hour)

--- a/dagsync/sync_test.go
+++ b/dagsync/sync_test.go
@@ -25,15 +25,13 @@ import (
 func TestLatestSyncSuccess(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
 
-	dstHost := test.MkTestHost()
+	dstHost := test.MkTestHost(t)
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
-	defer srcHost.Close()
-	defer dstHost.Close()
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -68,15 +66,13 @@ func TestSyncFn(t *testing.T) {
 	t.Parallel()
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
 
-	dstHost := test.MkTestHost()
+	dstHost := test.MkTestHost(t)
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
-	defer srcHost.Close()
-	defer dstHost.Close()
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -185,19 +181,16 @@ func TestPartialSync(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	testStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
 	testLnkS := test.MkLinkSystem(testStore)
 
 	chainLnks := test.MkChain(testLnkS, true)
 
-	dstHost := test.MkTestHost()
+	dstHost := test.MkTestHost(t)
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
-
-	defer srcHost.Close()
-	defer dstHost.Close()
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -252,10 +245,8 @@ func TestStepByStepSync(t *testing.T) {
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcLnkS := test.MkLinkSystem(srcStore)
 
-	srcHost := test.MkTestHost()
-	dstHost := test.MkTestHost()
-	defer srcHost.Close()
-	defer dstHost.Close()
+	srcHost := test.MkTestHost(t)
+	dstHost := test.MkTestHost(t)
 
 	topics := test.WaitForMeshWithMessage(t, testTopic, srcHost, dstHost)
 
@@ -295,8 +286,7 @@ func TestLatestSyncFailure(t *testing.T) {
 	t.Parallel()
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
-	defer srcHost.Close()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
 	require.NoError(t, err)
@@ -304,8 +294,7 @@ func TestLatestSyncFailure(t *testing.T) {
 
 	chainLnks := test.MkChain(srcLnkS, true)
 
-	dstHost := test.MkTestHost()
-	defer dstHost.Close()
+	dstHost := test.MkTestHost(t)
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
@@ -351,11 +340,9 @@ func TestLatestSyncFailure(t *testing.T) {
 func TestAnnounce(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
-	dstHost := test.MkTestHost()
-	defer srcHost.Close()
-	defer dstHost.Close()
+	dstHost := test.MkTestHost(t)
 
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
@@ -388,11 +375,9 @@ func TestAnnounce(t *testing.T) {
 func TestCancelDeadlock(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost := test.MkTestHost()
+	srcHost := test.MkTestHost(t)
 	srcLnkS := test.MkLinkSystem(srcStore)
-	dstHost := test.MkTestHost()
-	defer srcHost.Close()
-	defer dstHost.Close()
+	dstHost := test.MkTestHost(t)
 
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)

--- a/dagsync/test/util.go
+++ b/dagsync/test/util.go
@@ -192,12 +192,14 @@ func Store(srcStore datastore.Batching, n ipld.Node) (ipld.Link, error) {
 	return lsys.Store(ipld.LinkContext{}, schema.Linkproto, n)
 }
 
-func MkTestHost(options ...libp2p.Option) host.Host {
+func MkTestHost(t *testing.T, options ...libp2p.Option) host.Host {
 	options = append(options, libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	h, err := libp2p.New(options...)
+	require.NoError(t, err)
 	if err != nil {
 		panic(err)
 	}
+	t.Cleanup(func() { h.Close() })
 	return h
 }
 


### PR DESCRIPTION
This allows verification that the correct publisher address is being announced, even when no sync is happening to update provider information.