### PR TITLE
Filter out unspecified addresses when filtering announce addrs

### DIFF
--- a/announce/receiver.go
+++ b/announce/receiver.go
@@ -325,7 +325,7 @@ func (r *Receiver) handleAnnounce(ctx context.Context, amsg Announce, resend boo
 	}
 
 	if r.filterIPs {
-		amsg.Addrs = mautil.FilterPrivateIPs(amsg.Addrs)
+		amsg.Addrs = mautil.FilterPublic(amsg.Addrs)
 		// Even if there are no addresses left after filtering, continue
 		// because the others receiving the announce may be able to look up the
 		// address in their peer store.

--- a/mautil/mautil.go
+++ b/mautil/mautil.go
@@ -9,10 +9,9 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-// FilterPrivateIPs returns a new slice of multiaddrs with any private,
-// loopback, or unspecified IP multiaddrs removed. If no multiaddrs are
-// removed, then returns the original slice.
-func FilterPrivateIPs(maddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+// FilterPublic returns a new slice of multiaddrs with any private, loopback,
+// or unspecified multiaddrs removed.
+func FilterPublic(maddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 	filtered := multiaddr.FilterAddrs(maddrs, func(target multiaddr.Multiaddr) bool {
 		if target == nil {
 			return true
@@ -23,7 +22,7 @@ func FilterPrivateIPs(maddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 		}
 		switch c.Protocol().Code {
 		case multiaddr.P_IP4, multiaddr.P_IP6, multiaddr.P_IP6ZONE, multiaddr.P_IPCIDR:
-			return manet.IsPublicAddr(target)
+			return manet.IsPublicAddr(target) && !manet.IsIPUnspecified(target)
 		case multiaddr.P_DNS, multiaddr.P_DNS4, multiaddr.P_DNS6, multiaddr.P_DNSADDR:
 			return c.Value() != "localhost"
 		}

--- a/mautil/mautil_test.go
+++ b/mautil/mautil_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFilterPrivateIPs(t *testing.T) {
+func TestFilterPublic(t *testing.T) {
 	addrs := []string{
 		"/ip4/10.255.0.0/tcp/443",
 		"/ip4/11.0.0.0/tcp/80",
@@ -18,30 +18,29 @@ func TestFilterPrivateIPs(t *testing.T) {
 		"/dns4/example.net/tcp/1234",
 		"/ip4/127.0.0.1/tcp/9999",
 		"/dns4/localhost/tcp/1234",
+		"/ip6/::/tcp/3105/http",
+		"/ip4/0.0.0.0/tcp/3105",
 	}
 
 	maddrs, err := mautil.StringsToMultiaddrs(addrs)
 	require.NoError(t, err)
 
-	expected := make([]multiaddr.Multiaddr, 0, 3)
-	expected = append(expected, maddrs[1])
-	expected = append(expected, maddrs[3])
-	expected = append(expected, maddrs[5])
+	expected := []multiaddr.Multiaddr{maddrs[1], maddrs[3], maddrs[5]}
 
-	filtered := mautil.FilterPrivateIPs(maddrs)
+	filtered := mautil.FilterPublic(maddrs)
 	require.Equal(t, len(expected), len(filtered))
 
 	for i := range filtered {
 		require.Equal(t, expected[i], filtered[i])
 	}
 
-	filtered = mautil.FilterPrivateIPs(nil)
+	filtered = mautil.FilterPublic(nil)
 	require.Nil(t, filtered)
 }
 
-func TestFilterPrivateIPs_DoesNotPanicOnNilAddr(t *testing.T) {
+func TestFilterPublic_DoesNotPanicOnNilAddr(t *testing.T) {
 	original := []multiaddr.Multiaddr{nil}
-	got := mautil.FilterPrivateIPs(original)
+	got := mautil.FilterPublic(original)
 	// According to the function documentation, it should return the original slice.
 	require.Equal(t, original, got)
 }
@@ -65,6 +64,6 @@ func TestFindHTTPAddrs(t *testing.T) {
 		require.Equal(t, expected[i], filtered[i])
 	}
 
-	filtered = mautil.FilterPrivateIPs(nil)
+	filtered = mautil.FilterPublic(nil)
 	require.Nil(t, filtered)
 }


### PR DESCRIPTION
If unspecified addresses are included in the announce message, these need to be removed when filtering addresses. Unspecified addresses are [::] or 0.0.0.0.

Rename `mautil.FilterPrivateIPs` to `mautil.FilterPublic`