### PR TITLE
libp2p + HTTP an exploratory refactor

### DIFF
--- a/dagsync/httpsync/publisher.go
+++ b/dagsync/httpsync/publisher.go
@@ -131,6 +131,26 @@ func NewPublisherWithoutServer(address string, handlerPath string, lsys ipld.Lin
 	}, nil
 }
 
+// NewPublisherHandler returns a Publisher for use as an http.Handler. Doesn't listen or know about a url prefix.
+func NewPublisherHandler(lsys ipld.LinkSystem, privKey ic.PrivKey) (*Publisher, error) {
+	if privKey == nil {
+		return nil, errors.New("private key required to sign head requests")
+	}
+	peerID, err := peer.IDFromPrivateKey(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not get peer id from private key: %w", err)
+	}
+
+	return &Publisher{
+		addr:        nil,
+		closer:      io.NopCloser(nil),
+		lsys:        lsys,
+		handlerPath: "",
+		peerID:      peerID,
+		privKey:     privKey,
+	}, nil
+}
+
 // Addrs returns the addresses, as []multiaddress, that the Publisher is
 // listening on.
 func (p *Publisher) Addrs() []multiaddr.Multiaddr {

--- a/dagsync/httpsync/publisher_test.go
+++ b/dagsync/httpsync/publisher_test.go
@@ -168,17 +168,17 @@ func TestPublisherWithLibp2pHTTP(t *testing.T) {
 			clientHost, err := libp2phttp.New()
 			req.NoError(err)
 
-			c, err := clientHost.NamespacedClient(nil, protoID, peer.AddrInfo{Addrs: []multiaddr.Multiaddr{serverHTTPMa}})
+			c, err := clientHost.NamespacedClient(protoID, peer.AddrInfo{Addrs: []multiaddr.Multiaddr{serverHTTPMa}})
 			req.NoError(err)
 			return &c
 		}},
 		{"libp2p stream transport", func(t *testing.T) *http.Client {
 			clientStreamHost, err := libp2p.New(libp2p.NoListenAddrs)
 			req.NoError(err)
-			clientHost, err := libp2phttp.New()
+			clientHost, err := libp2phttp.New(libp2phttp.StreamHost(clientStreamHost))
 			req.NoError(err)
 
-			c, err := clientHost.NamespacedClient(clientStreamHost, protoID, peer.AddrInfo{ID: publisherStreamHost.ID(), Addrs: []multiaddr.Multiaddr{serverStreamMa}})
+			c, err := clientHost.NamespacedClient(protoID, peer.AddrInfo{ID: publisherStreamHost.ID(), Addrs: []multiaddr.Multiaddr{serverStreamMa}})
 			req.NoError(err)
 
 			wk, err := clientHost.GetAndStorePeerProtoMap(c.Transport, publisherStreamHost.ID())

--- a/dagsync/httpsync/sync.go
+++ b/dagsync/httpsync/sync.go
@@ -69,6 +69,15 @@ func (s *Sync) NewSyncer(peerID peer.ID, peerAddrs []multiaddr.Multiaddr) (*Sync
 	}, nil
 }
 
+func (s *Sync) NewSyncerWithoutAddrs(peerID peer.ID) (*Syncer, error) {
+	return &Syncer{
+		peerID:  peerID,
+		rootURL: url.URL{Path: "/"},
+		urls:    nil,
+		sync:    s,
+	}, nil
+}
+
 func (s *Sync) Close() {
 	s.client.CloseIdleConnections()
 }

--- a/go.mod
+++ b/go.mod
@@ -138,3 +138,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.2.1 // indirect
 )
+
+replace github.com/libp2p/go-libp2p v0.29.0 => ../../libp2p/go-libp2p

--- a/go.mod
+++ b/go.mod
@@ -139,4 +139,4 @@ require (
 	lukechampine.com/blake3 v1.2.1 // indirect
 )
 
-replace github.com/libp2p/go-libp2p v0.29.0 => github.com/libp2p/go-libp2p v0.29.1-0.20230804013835-61da6d1db6a8
+replace github.com/libp2p/go-libp2p v0.29.0 => github.com/libp2p/go-libp2p v0.29.1-0.20230804182920-49d7db486c5e

--- a/go.mod
+++ b/go.mod
@@ -139,4 +139,4 @@ require (
 	lukechampine.com/blake3 v1.2.1 // indirect
 )
 
-replace github.com/libp2p/go-libp2p v0.29.0 => ../../libp2p/go-libp2p
+replace github.com/libp2p/go-libp2p v0.29.0 => github.com/libp2p/go-libp2p v0.29.1-0.20230804013835-61da6d1db6a8

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38y
 github.com/libp2p/go-cidranger v1.1.0/go.mod h1:KWZTfSr+r9qEo9OkI9/SIEeAtw+NNoU0dXIXt15Okic=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=
 github.com/libp2p/go-flow-metrics v0.1.0/go.mod h1:4Xi8MX8wj5aWNDAZttg6UPmc0ZrnFNsMtpsYUClFtro=
-github.com/libp2p/go-libp2p v0.29.1-0.20230802215643-440fdb670a4d h1:DDtqSFme820l4G7UitXkihpyaZYTRz0Y1GM1hnLtAIk=
-github.com/libp2p/go-libp2p v0.29.1-0.20230802215643-440fdb670a4d/go.mod h1:iNKL7mEnZ9wAss+03IjAwM9ZAQXfVUAPUUmOACQfQ/g=
+github.com/libp2p/go-libp2p v0.29.1-0.20230804013835-61da6d1db6a8 h1:2jxDMRzd1Nba+hDLVzpdHEWnz46/23J0rB1l7PYKOGk=
+github.com/libp2p/go-libp2p v0.29.1-0.20230804013835-61da6d1db6a8/go.mod h1:iNKL7mEnZ9wAss+03IjAwM9ZAQXfVUAPUUmOACQfQ/g=
 github.com/libp2p/go-libp2p-asn-util v0.3.0 h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=
 github.com/libp2p/go-libp2p-asn-util v0.3.0/go.mod h1:B1mcOrKUE35Xq/ASTmQ4tN3LNzVVaMNmq2NACuqyB9w=
 github.com/libp2p/go-libp2p-gostream v0.6.0 h1:QfAiWeQRce6pqnYfmIVWJFXNdDyfiR/qkCnjyaZUPYU=

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38y
 github.com/libp2p/go-cidranger v1.1.0/go.mod h1:KWZTfSr+r9qEo9OkI9/SIEeAtw+NNoU0dXIXt15Okic=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=
 github.com/libp2p/go-flow-metrics v0.1.0/go.mod h1:4Xi8MX8wj5aWNDAZttg6UPmc0ZrnFNsMtpsYUClFtro=
-github.com/libp2p/go-libp2p v0.29.1-0.20230804013835-61da6d1db6a8 h1:2jxDMRzd1Nba+hDLVzpdHEWnz46/23J0rB1l7PYKOGk=
-github.com/libp2p/go-libp2p v0.29.1-0.20230804013835-61da6d1db6a8/go.mod h1:iNKL7mEnZ9wAss+03IjAwM9ZAQXfVUAPUUmOACQfQ/g=
+github.com/libp2p/go-libp2p v0.29.1-0.20230804182920-49d7db486c5e h1:OGUuDNhPAEt58YoUW5fSSB1XeQB3k5OFPokuLc1KVeA=
+github.com/libp2p/go-libp2p v0.29.1-0.20230804182920-49d7db486c5e/go.mod h1:iNKL7mEnZ9wAss+03IjAwM9ZAQXfVUAPUUmOACQfQ/g=
 github.com/libp2p/go-libp2p-asn-util v0.3.0 h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=
 github.com/libp2p/go-libp2p-asn-util v0.3.0/go.mod h1:B1mcOrKUE35Xq/ASTmQ4tN3LNzVVaMNmq2NACuqyB9w=
 github.com/libp2p/go-libp2p-gostream v0.6.0 h1:QfAiWeQRce6pqnYfmIVWJFXNdDyfiR/qkCnjyaZUPYU=

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38y
 github.com/libp2p/go-cidranger v1.1.0/go.mod h1:KWZTfSr+r9qEo9OkI9/SIEeAtw+NNoU0dXIXt15Okic=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=
 github.com/libp2p/go-flow-metrics v0.1.0/go.mod h1:4Xi8MX8wj5aWNDAZttg6UPmc0ZrnFNsMtpsYUClFtro=
-github.com/libp2p/go-libp2p v0.29.0 h1:QduJ2XQr/Crg4EnloueWDL0Jj86N3Ezhyyj7XH+XwHI=
-github.com/libp2p/go-libp2p v0.29.0/go.mod h1:iNKL7mEnZ9wAss+03IjAwM9ZAQXfVUAPUUmOACQfQ/g=
+github.com/libp2p/go-libp2p v0.29.1-0.20230802215643-440fdb670a4d h1:DDtqSFme820l4G7UitXkihpyaZYTRz0Y1GM1hnLtAIk=
+github.com/libp2p/go-libp2p v0.29.1-0.20230802215643-440fdb670a4d/go.mod h1:iNKL7mEnZ9wAss+03IjAwM9ZAQXfVUAPUUmOACQfQ/g=
 github.com/libp2p/go-libp2p-asn-util v0.3.0 h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=
 github.com/libp2p/go-libp2p-asn-util v0.3.0/go.mod h1:B1mcOrKUE35Xq/ASTmQ4tN3LNzVVaMNmq2NACuqyB9w=
 github.com/libp2p/go-libp2p-gostream v0.6.0 h1:QfAiWeQRce6pqnYfmIVWJFXNdDyfiR/qkCnjyaZUPYU=


### PR DESCRIPTION
Hi folks!

I'm play-testing the new libp2p+HTTP api https://github.com/libp2p/go-libp2p/pull/2438 so I wanted to try using it somewhere. I think the dagsync code here would benefit from libp2p+HTTP because:

1. It means you can delete all of `dagsync/dtsync` eventually (after clients upgrade).
2. It consolidates the http and libp2p stream logic.
3. You no longer have to manage the prefix logic. That is built into libp2p+HTTP.
   a. This means your client and server are also simpler. You can toss all the prefix logic into the trash!
   
I've added a test case that shows a simple head fetch and sync over HTTP both on top of a native HTTP transport and a libp2p stream.

I'd love feedback on what you think about this API.

cc @masih 