### PR TITLE
Configurable concurrency limit for async syncs

### DIFF
--- a/announce/receiver.go
+++ b/announce/receiver.go
@@ -304,12 +304,12 @@ func (r *Receiver) watch(ctx context.Context) {
 // message extra data. The peerID and addrs are those of the advertisement
 // publisher, since an announce message announces the availability of an
 // advertisement and where to retrieve it from.
-func (r *Receiver) Direct(ctx context.Context, nextCid cid.Cid, peerID peer.ID, addrs []multiaddr.Multiaddr) error {
-	log.Infow("Handling direct announce", "peer", peerID, "addrs", addrs)
+func (r *Receiver) Direct(ctx context.Context, nextCid cid.Cid, peerInfo peer.AddrInfo) error {
+	log.Infow("Handling direct announce", "peer", peerInfo.ID, "addrs", peerInfo.Addrs)
 	amsg := Announce{
 		Cid:    nextCid,
-		PeerID: peerID,
-		Addrs:  addrs,
+		PeerID: peerInfo.ID,
+		Addrs:  peerInfo.Addrs,
 	}
 	return r.handleAnnounce(ctx, amsg, r.resend)
 }

--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -166,7 +166,7 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 	// Announce one CID to the subscriber. Note that announce does a sync in the background.
 	// That's why we use one cid here and another for sync so that we can concretely assert that
 	// data was synced via the sync call and not via the earlier background sync via announce.
-	err = sub.Announce(ctx, oneC, peer.AddrInfo{pubh.ID(), pub.Addrs()})
+	err = sub.Announce(ctx, oneC, peer.AddrInfo{ID: pubh.ID(), Addrs: pub.Addrs()})
 	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()

--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -28,6 +28,10 @@ func TestAnnounceReplace(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcHost := test.MkTestHost(t)
+	srcHostInfo := peer.AddrInfo{
+		ID:    srcHost.ID(),
+		Addrs: srcHost.Addrs(),
+	}
 	srcLnkS := test.MkLinkSystem(srcStore)
 	dstHost := test.MkTestHost(t)
 
@@ -61,7 +65,7 @@ func TestAnnounceReplace(t *testing.T) {
 
 	// Have the subscriber receive an announce.  This is the same as if it was
 	// published by the publisher without having to wait for it to arrive.
-	err = sub.Announce(context.Background(), firstCid, srcHost.ID(), srcHost.Addrs())
+	err = sub.Announce(context.Background(), firstCid, srcHostInfo)
 	require.NoError(t, err)
 	t.Log("Sent announce for first CID", firstCid)
 
@@ -74,13 +78,13 @@ func TestAnnounceReplace(t *testing.T) {
 	// Announce two more times.
 	c := chainLnks[1].(cidlink.Link).Cid
 	pub.SetRoot(c)
-	err = sub.Announce(context.Background(), c, srcHost.ID(), srcHost.Addrs())
+	err = sub.Announce(context.Background(), c, srcHostInfo)
 	require.NoError(t, err)
 	t.Log("Sent announce for second CID", c)
 
 	lastCid := chainLnks[0].(cidlink.Link).Cid
 	pub.SetRoot(lastCid)
-	err = sub.Announce(context.Background(), lastCid, srcHost.ID(), srcHost.Addrs())
+	err = sub.Announce(context.Background(), lastCid, srcHostInfo)
 	require.NoError(t, err)
 	t.Log("Sent announce for last CID", lastCid)
 
@@ -162,7 +166,7 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 	// Announce one CID to the subscriber. Note that announce does a sync in the background.
 	// That's why we use one cid here and another for sync so that we can concretely assert that
 	// data was synced via the sync call and not via the earlier background sync via announce.
-	err = sub.Announce(ctx, oneC, pubh.ID(), pub.Addrs())
+	err = sub.Announce(ctx, oneC, peer.AddrInfo{pubh.ID(), pub.Addrs()})
 	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
@@ -192,6 +196,10 @@ func TestAnnounceRepublish(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcHost := test.MkTestHost(t)
+	srcHostInfo := peer.AddrInfo{
+		ID:    srcHost.ID(),
+		Addrs: srcHost.Addrs(),
+	}
 	srcLnkS := test.MkLinkSystem(srcStore)
 	dstHost := test.MkTestHost(t)
 
@@ -231,7 +239,7 @@ func TestAnnounceRepublish(t *testing.T) {
 	pub.SetRoot(firstCid)
 
 	// Announce one CID to subscriber1.
-	err = sub1.Announce(context.Background(), firstCid, srcHost.ID(), srcHost.Addrs())
+	err = sub1.Announce(context.Background(), firstCid, srcHostInfo)
 	require.NoError(t, err)
 	t.Log("Sent announce for first CID", firstCid)
 

--- a/dagsync/subscriber_test.go
+++ b/dagsync/subscriber_test.go
@@ -653,11 +653,11 @@ func TestMaxAsyncSyncs(t *testing.T) {
 	rootCid2 := lnk2.(cidlink.Link).Cid
 	pub2.SetRoot(rootCid2)
 
-	err = sub.Announce(context.Background(), rootCid1, peer.AddrInfo{pub1.ID(), pub1.Addrs()})
+	err = sub.Announce(context.Background(), rootCid1, peer.AddrInfo{ID: pub1.ID(), Addrs: pub1.Addrs()})
 	require.NoError(t, err)
 	t.Log("Publish 1:", lnk1.(cidlink.Link).Cid)
 
-	err = sub.Announce(context.Background(), rootCid2, peer.AddrInfo{pub2.ID(), pub2.Addrs()})
+	err = sub.Announce(context.Background(), rootCid2, peer.AddrInfo{ID: pub2.ID(), Addrs: pub2.Addrs()})
 	require.NoError(t, err)
 	t.Log("Publish 2:", lnk2.(cidlink.Link).Cid)
 
@@ -729,11 +729,11 @@ func TestMaxAsyncSyncs(t *testing.T) {
 	require.NoError(t, err)
 	defer sub.Close()
 
-	err = sub.Announce(context.Background(), rootCid1, peer.AddrInfo{pub1.ID(), pub1.Addrs()})
+	err = sub.Announce(context.Background(), rootCid1, peer.AddrInfo{ID: pub1.ID(), Addrs: pub1.Addrs()})
 	require.NoError(t, err)
 	t.Log("Publish 1:", lnk1.(cidlink.Link).Cid)
 
-	err = sub.Announce(context.Background(), rootCid2, peer.AddrInfo{pub2.ID(), pub2.Addrs()})
+	err = sub.Announce(context.Background(), rootCid2, peer.AddrInfo{ID: pub2.ID(), Addrs: pub2.Addrs()})
 	require.NoError(t, err)
 	t.Log("Publish 2:", lnk2.(cidlink.Link).Cid)
 

--- a/dagsync/subscriber_test.go
+++ b/dagsync/subscriber_test.go
@@ -602,6 +602,165 @@ func TestSyncFinishedAlwaysDelivered(t *testing.T) {
 	require.Equal(t, 3, count)
 }
 
+func TestMaxAsyncSyncs(t *testing.T) {
+	// Create two publishers
+	srcStore1 := dssync.MutexWrap(datastore.NewMapDatastore())
+	srcHost1 := test.MkTestHost(t)
+	srcLnkS1 := test.MkLinkSystem(srcStore1)
+	pub1, err := dtsync.NewPublisher(srcHost1, srcStore1, srcLnkS1, "")
+	require.NoError(t, err)
+	defer pub1.Close()
+
+	srcStore2 := dssync.MutexWrap(datastore.NewMapDatastore())
+	srcHost2 := test.MkTestHost(t)
+	srcLnkS2 := test.MkLinkSystem(srcStore2)
+	pub2, err := dtsync.NewPublisher(srcHost2, srcStore2, srcLnkS2, "")
+	require.NoError(t, err)
+	defer pub2.Close()
+
+	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
+	dstHost := test.MkTestHost(t)
+	dstLnkS, blocked := test.MkBlockedLinkSystem(dstStore)
+	blocksSeenByHook := make(map[cid.Cid]struct{})
+	blockHook := func(p peer.ID, c cid.Cid, _ dagsync.SegmentSyncActions) {
+		blocksSeenByHook[c] = struct{}{}
+	}
+
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic,
+		dagsync.RecvAnnounce(),
+		dagsync.BlockHook(blockHook),
+		dagsync.StrictAdsSelector(false),
+		// If this value is > 1, then test must fail.
+		dagsync.MaxAsyncConcurrency(1),
+	)
+	require.NoError(t, err)
+	defer sub.Close()
+
+	watcher, cncl := sub.OnSyncFinished()
+	defer cncl()
+
+	// Update root on publisher1 with item
+	itm1 := basicnode.NewString("hello world")
+	lnk1, err := test.Store(srcStore1, itm1)
+	require.NoError(t, err)
+	rootCid1 := lnk1.(cidlink.Link).Cid
+	pub1.SetRoot(rootCid1)
+
+	// Update root on publisher2 with item
+	itm2 := basicnode.NewString("hello world 2")
+	lnk2, err := test.Store(srcStore2, itm2)
+	require.NoError(t, err)
+	rootCid2 := lnk2.(cidlink.Link).Cid
+	pub2.SetRoot(rootCid2)
+
+	err = sub.Announce(context.Background(), rootCid1, peer.AddrInfo{pub1.ID(), pub1.Addrs()})
+	require.NoError(t, err)
+	t.Log("Publish 1:", lnk1.(cidlink.Link).Cid)
+
+	err = sub.Announce(context.Background(), rootCid2, peer.AddrInfo{pub2.ID(), pub2.Addrs()})
+	require.NoError(t, err)
+	t.Log("Publish 2:", lnk2.(cidlink.Link).Cid)
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+
+	var release chan<- struct{}
+	select {
+	case release = <-blocked:
+	case <-timer.C:
+		t.Fatal("timed out waiting for sync 1")
+	}
+	select {
+	case <-timer.C:
+	case release2 := <-blocked:
+		close(release)
+		close(release2)
+		var done bool
+		for !done {
+			select {
+			case release2 = <-blocked:
+				close(release2)
+			case <-timer.C:
+				done = true
+			}
+		}
+		t.Fatal("unexpected sync when sync blocked and concurrency set to 1")
+	}
+
+	close(release)
+
+	timer.Reset(updateTimeout)
+	select {
+	case <-timer.C:
+		t.Fatal("timed out waiting for sync 2")
+	case release2 := <-blocked:
+		close(release2)
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-timer.C:
+			t.Fatal("timed out waiting for sync")
+		case downstream := <-watcher:
+			t.Log("got sync:", downstream.Cid)
+		}
+	}
+	timer.Stop()
+
+	_, ok := blocksSeenByHook[lnk1.(cidlink.Link).Cid]
+	require.True(t, ok, "hook did not see link1")
+
+	_, ok = blocksSeenByHook[lnk2.(cidlink.Link).Cid]
+	require.True(t, ok, "hook did not see link2")
+
+	// ----- Check concurrenty > 1 -----
+
+	dstStore = dssync.MutexWrap(datastore.NewMapDatastore())
+	dstHost = test.MkTestHost(t)
+	dstLnkS, blocked = test.MkBlockedLinkSystem(dstStore)
+	blocksSeenByHook = make(map[cid.Cid]struct{})
+
+	sub, err = dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic,
+		dagsync.RecvAnnounce(),
+		dagsync.BlockHook(blockHook),
+		dagsync.StrictAdsSelector(false),
+		dagsync.MaxAsyncConcurrency(2),
+	)
+	require.NoError(t, err)
+	defer sub.Close()
+
+	err = sub.Announce(context.Background(), rootCid1, peer.AddrInfo{pub1.ID(), pub1.Addrs()})
+	require.NoError(t, err)
+	t.Log("Publish 1:", lnk1.(cidlink.Link).Cid)
+
+	err = sub.Announce(context.Background(), rootCid2, peer.AddrInfo{pub2.ID(), pub2.Addrs()})
+	require.NoError(t, err)
+	t.Log("Publish 2:", lnk2.(cidlink.Link).Cid)
+
+	timer = time.NewTimer(time.Second)
+	select {
+	case release = <-blocked:
+	case <-timer.C:
+		t.Fatal("timed out waiting for sync 1")
+	}
+	select {
+	case <-timer.C:
+		t.Fatal("expected another sync")
+	case release2 := <-blocked:
+		close(release)
+		close(release2)
+		var done bool
+		for !done {
+			select {
+			case release2 = <-blocked:
+				close(release2)
+			case <-timer.C:
+				done = true
+			}
+		}
+	}
+}
+
 func waitForSync(t *testing.T, logPrefix string, store *dssync.MutexDatastore, expectedCid cidlink.Link, watcher <-chan dagsync.SyncFinished) {
 	select {
 	case <-time.After(updateTimeout):


### PR DESCRIPTION
The number of concurrent advertisement chain syncs, started in response to announcements, can be limited by a configurable value. This is necessary when there are many providers that have advertisement chains to sync and syncing them all at the same time would cause memory exhaustion.

Other changes:
- Remove the ability to use an external data-transfer Manager.
- The announce API takes peer.AddrInfo instead of peer.ID and []multiaddr.Multiaddr

Fixes #101