### PR TITLE
Option for double-hashed lookups to return only metadata

### DIFF
--- a/find/client/option.go
+++ b/find/client/option.go
@@ -16,6 +16,7 @@ type config struct {
 	providersURLs []string
 	dhstoreURL    string
 	dhstoreAPI    DHStoreAPI
+	metadataOnly  bool
 	pcacheTTL     time.Duration
 	preload       bool
 }
@@ -48,9 +49,22 @@ func WithClient(c *http.Client) Option {
 	}
 }
 
+// WithMetadataOnly configures lookups to only return metadata and not provider
+// information. This means that is it is not necessary to specify providers
+// URLs, using WithProvidersURL, when provider information is available from a
+// separate location.
+func WithMetadataOnly(metadataOnly bool) Option {
+	return func(cfg *config) error {
+		cfg.metadataOnly = metadataOnly
+		return nil
+	}
+}
+
 // WithProvidersURL specifies one or more URLs for retrieving provider
 // information (/providers and /providers/<pid> endpoints). Multiple URLs may
-// be given to specify multiple sources of provider information,
+// be given to specify multiple sources of provider information.
+//
+// This option is ignored if WithMetadataOnly(true) is specified.
 func WithProvidersURL(urls ...string) Option {
 	return func(cfg *config) error {
 		cfg.providersURLs = append(cfg.providersURLs, urls...)
@@ -80,6 +94,8 @@ func WithDHStoreAPI(dhsAPI DHStoreAPI) Option {
 
 // WithPcacheTTL sets the time that provider information remains in the cache
 // after it is not longer available from any of the original sources.
+//
+// This option is ignored if WithMetadataOnly(true) is specified.
 func WithPcacheTTL(ttl time.Duration) Option {
 	return func(cfg *config) error {
 		cfg.pcacheTTL = ttl
@@ -91,7 +107,8 @@ func WithPcacheTTL(ttl time.Duration) Option {
 // should be enabled, even for short-lived clients needing to look up few
 // providers.
 //
-// Default is true (enabled).
+// Default is true (enabled). This option is ignored if WithMetadataOnly(true)
+// is specified.
 func WithPcachePreload(preload bool) Option {
 	return func(cfg *config) error {
 		cfg.preload = preload

--- a/pcache/provider_cache.go
+++ b/pcache/provider_cache.go
@@ -19,7 +19,7 @@ var log = logging.Logger("pcache")
 var ErrClosed = errors.New("cache closed")
 
 // ProviderSource in an interface that the cache uses to fetch provider
-// information for one or all providers from a specific supplier of that
+// information. Each ProviderSource is a specific supplier of provider
 // information. The cache can be configured with any number of sources that
 // supply provider information.
 type ProviderSource interface {
@@ -153,10 +153,11 @@ func (pc *ProviderCache) List() []*model.ProviderInfo {
 	return pinfos
 }
 
-// GetResults retrieves information about the provicer specified by pid and
-// composes a slice ProviderResults got the provider. If provider information
-// is not available, then a nil slice is returned. An error results from the
-// context being canceled or the cache closing.
+// GetResults retrieves information about the provider specified by peer ID and
+// composes a slice of ProviderResults for the provider and any extended
+// providers. If provider information is not available, then a nil slice is
+// returned. An error results from the context being canceled or the cache
+// closing.
 func (pc *ProviderCache) GetResults(ctx context.Context, pid peer.ID, ctxID, metadata []byte) ([]model.ProviderResult, error) {
 	rpi, err := pc.getReadOnly(ctx, pid)
 	if err != nil {
@@ -190,7 +191,7 @@ func (pc *ProviderCache) GetResults(ctx context.Context, pid peer.ID, ctxID, met
 		override = ctxExtended.override
 		for i, xpinfo := range ctxExtended.providers {
 			xmd := ctxExtended.metadatas[i]
-			// Skippng the main provider's record if its metadata is nil or is
+			// Skipping the main provider's record if its metadata is nil or is
 			// the same as the one retrieved from the indexer, because such EP
 			// record does not advertise any new protocol.
 			if xpinfo.ID == pid && (len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
@@ -219,7 +220,7 @@ func (pc *ProviderCache) GetResults(ctx context.Context, pid peer.ID, ctxID, met
 	extended := rpi.provider.ExtendedProviders
 	for i, xpinfo := range extended.Providers {
 		xmd := extended.Metadatas[i]
-		// Skippng the main provider's record if its metadata is nil or is the
+		// Skipping the main provider's record if its metadata is nil or is the
 		// same as the one retrieved from the indexer, because such EP record
 		// does not advertise any new protocol.
 		if xpinfo.ID == pid && (len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
@@ -362,7 +363,7 @@ func (pc *ProviderCache) Refresh(ctx context.Context) error {
 	return nil
 }
 
-// get returns the provider information for the provider specified by pid. If
+// get returns the provider information for the provider specified by id. If
 // provider information is not available, then a nil slice is returned. An
 // error results from the context being canceled or the cache closing.
 //


### PR DESCRIPTION
Supports use cases where provider address information is not needed.

Fixes #122