### PR TITLE
Remove unused addrs from peerstore

### DIFF
--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -475,7 +475,7 @@ func (s *Subscriber) SyncAdChain(ctx context.Context, peerInfo peer.AddrInfo, op
 	}
 
 	log = log.With("cid", nextCid)
-	log.Debug("Start advertisement chain sync at head CID")
+	log.Debug("Start advertisement chain sync")
 
 	if ctx.Err() != nil {
 		return cid.Undef, fmt.Errorf("sync canceled: %w", ctx.Err())


### PR DESCRIPTION
Remove unused addrs from peerstore to prevent addresses that are no longer valid from continuing to be used.

Confirmed this to fix a publisher address that was no longer valid and should have been replaced by a different address.

Fixes #127

Update non-critical log messages to log at debug level.