### PR TITLE
Fix leak when find client returns not found

### DIFF
--- a/dagsync/ipnisync/sync.go
+++ b/dagsync/ipnisync/sync.go
@@ -308,6 +308,7 @@ nextURL:
 	case http.StatusOK:
 		return cb(resp.Body)
 	case http.StatusNotFound:
+		io.Copy(io.Discard, resp.Body)
 		if s.plainHTTP && !s.noPath {
 			// Try again with no path for legacy http.
 			log.Warnw("Plain HTTP got not found response, retrying without IPNI path for legacy HTTP")
@@ -321,6 +322,7 @@ nextURL:
 		// being checked already.
 		return fmt.Errorf("content not found: %w", ipld.ErrNotExists{})
 	case http.StatusForbidden:
+		io.Copy(io.Discard, resp.Body)
 		if s.plainHTTP && !s.noPath {
 			// Try again with no path for legacy http.
 			log.Warnw("Plain HTTP got forbidden response, retrying without IPNI path for legacy HTTP")
@@ -330,6 +332,7 @@ nextURL:
 		}
 		fallthrough
 	default:
+		io.Copy(io.Discard, resp.Body)
 		return fmt.Errorf("non success http fetch response at %s: %d", fetchURL.String(), resp.StatusCode)
 	}
 }

--- a/find/client/client.go
+++ b/find/client/client.go
@@ -73,6 +73,7 @@ func (c *Client) Find(ctx context.Context, m multihash.Multihash) (*model.FindRe
 
 	// Handle failed requests
 	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
 		if resp.StatusCode == http.StatusNotFound {
 			return &model.FindResponse{}, nil
 		}

--- a/find/client/client.go
+++ b/find/client/client.go
@@ -69,6 +69,8 @@ func (c *Client) Find(ctx context.Context, m multihash.Multihash) (*model.FindRe
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	// Handle failed requests
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
@@ -77,7 +79,6 @@ func (c *Client) Find(ctx context.Context, m multihash.Multihash) (*model.FindRe
 		return nil, fmt.Errorf("find query failed: %v", http.StatusText(resp.StatusCode))
 	}
 
-	defer resp.Body.Close()
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/find/client/dhstore_http.go
+++ b/find/client/dhstore_http.go
@@ -33,10 +33,9 @@ func (d *dhstoreHTTP) FindMultihash(ctx context.Context, dhmh multihash.Multihas
 	if err != nil {
 		return nil, err
 	}
-
-	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -70,10 +69,9 @@ func (d *dhstoreHTTP) FindMetadata(ctx context.Context, hvk []byte) ([]byte, err
 	if err != nil {
 		return nil, err
 	}
-
-	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pcache/http_source.go
+++ b/pcache/http_source.go
@@ -108,8 +108,6 @@ func (s *httpSource) FetchAll(ctx context.Context) ([]*model.ProviderInfo, error
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The find client is not closing the response body when it gets a not found response. This PR fixes that.