### PR TITLE
Add function to create general dagsync blockhook function

### DIFF
--- a/dagsync/option.go
+++ b/dagsync/option.go
@@ -311,13 +311,16 @@ func ScopedBlockHook(hook BlockHookFunc) SyncOption {
 	}
 }
 
-// MakeGeneralBlockHook creates a block hook function that loads an
-// advertisement and sets the next sync action.
+// MakeGeneralBlockHook creates a block hook function that sets the next sync
+// action based on whether the specified advertisement has a previous
+// advertisement in the chain..
 //
 // Use this when segmented sync is enabled and no other blockhook is defined.
 //
 // The supplied prevAdCid function takes the CID of the current advertisement
-// and returns the CID of the previous advertisement in the chain.
+// and returns the CID of the previous advertisement in the chain. This would
+// typically be done my loading the specified advertisement from the
+// ipld.LinkSystem and getting the previous CID.
 func MakeGeneralBlockHook(prevAdCid func(adCid cid.Cid) (cid.Cid, error)) BlockHookFunc {
 	return func(_ peer.ID, adCid cid.Cid, actions SegmentSyncActions) {
 		// The only kind of block we should get by loading CIDs here should be

--- a/dagsync/option.go
+++ b/dagsync/option.go
@@ -316,8 +316,7 @@ func ScopedBlockHook(hook BlockHookFunc) SyncOption {
 // MakeGeneralBlockHook creates a block hook function that loads an
 // advertisement and sets the next sync action.
 //
-// Use this when segmented sync is enabled and no other blockhook is not
-// defined.
+// Use this when segmented sync is enabled and no other blockhook is defined.
 //
 // The supplied loadAd function loads an advertisement, generally stored by the
 // subscriber's LinkSystem.
@@ -327,8 +326,8 @@ func MakeGeneralBlockHook(loadAd func(c cid.Cid) (schema.Advertisement, error)) 
 		// Advertisement.
 		//
 		// Because:
-		//  - the default subscription selector only selects advertisements.
-		//  - entries are synced with an explicit selector separate from
+		//  - The default subscription selector only selects advertisements.
+		//  - Entries are synced with an explicit selector separate from
 		//    advertisement syncs and should use dagsync.ScopedBlockHook to
 		//    override this hook and decode chunks instead.
 		//

--- a/ingest/schema/types.go
+++ b/ingest/schema/types.go
@@ -91,6 +91,8 @@ func UnwrapAdvertisement(node ipld.Node) (*Advertisement, error) {
 	return ad, nil
 }
 
+// Return the Advertisement's previous CID, or cid.Undef if there is no
+// previous CID.
 func (a Advertisement) PreviousCid() cid.Cid {
 	if a.PreviousID == nil {
 		return cid.Undef
@@ -110,6 +112,9 @@ func (a Advertisement) Validate() error {
 	return nil
 }
 
+// BytesToAdvertisement deserializes an Advertisement from a buffer. It does
+// not check that the given CID matches the data, as this should have been done
+// when the data was acquired.
 func BytesToAdvertisement(adCid cid.Cid, data []byte) (Advertisement, error) {
 	adNode, err := decodeIPLDNode(adCid.Prefix().Codec, bytes.NewBuffer(data), AdvertisementPrototype)
 	if err != nil {
@@ -122,7 +127,10 @@ func BytesToAdvertisement(adCid cid.Cid, data []byte) (Advertisement, error) {
 	return *ad, nil
 }
 
-func BytesToEntry(entCid cid.Cid, data []byte) (EntryChunk, error) {
+// BytesToEntryChunk deserializes an EntryChunk from a buffer. It does not
+// check that the given CID matches the data, as this should have been done
+// when the data was acquired.
+func BytesToEntryChunk(entCid cid.Cid, data []byte) (EntryChunk, error) {
 	entNode, err := decodeIPLDNode(entCid.Prefix().Codec, bytes.NewBuffer(data), EntryChunkPrototype)
 	if err != nil {
 		return EntryChunk{}, err


### PR DESCRIPTION
A general blockhook function is commonly used by clients of this library when segmented syncs are enbled.