### PR TITLE
Configurable first sync depth

### DIFF
--- a/dagsync/option.go
+++ b/dagsync/option.go
@@ -45,6 +45,7 @@ type config struct {
 
 	adsDepthLimit     int64
 	entriesDepthLimit int64
+	firstSyncDepth    int64
 	segDepthLimit     int64
 
 	strictAdsSelSeq bool
@@ -162,6 +163,18 @@ func AdsDepthLimit(limit int64) Option {
 func EntriesDepthLimit(depth int64) Option {
 	return func(c *config) error {
 		c.entriesDepthLimit = depth
+		return nil
+	}
+}
+
+// FirstSyncDepth sets the advertisement chain depth to sync on the first sync
+// with a new provider. A value of 0, the default, means unlimited depth.
+func FirstSyncDepth(depth int64) Option {
+	return func(c *config) error {
+		if depth < 0 {
+			depth = 0
+		}
+		c.firstSyncDepth = depth
 		return nil
 	}
 }

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -136,7 +136,7 @@ type SyncFinished struct {
 	// PeerID identifies the peer this SyncFinished event pertains to. This is
 	// the publisher of the advertisement chain.
 	PeerID peer.ID
-	// Count is the number of CID synced.
+	// Count is the number of CIDs synced.
 	Count int
 	// Err is used to return a failure to complete an asynchronous sync in
 	// response to an announcement.

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -99,8 +99,9 @@ type Subscriber struct {
 	// async syncs.
 	syncSem chan struct{}
 
-	adsDepthLimit selector.RecursionLimit
-	segDepthLimit int64
+	adsDepthLimit  selector.RecursionLimit
+	firstSyncDepth int64
+	segDepthLimit  int64
 
 	receiver *announce.Receiver
 
@@ -223,8 +224,9 @@ func NewSubscriber(host host.Host, lsys ipld.LinkSystem, options ...Option) (*Su
 		latestSyncHandler: latestSyncHandler{},
 		lastKnownSync:     opts.lastKnownSync,
 
-		adsDepthLimit: recursionLimit(opts.adsDepthLimit),
-		segDepthLimit: opts.segDepthLimit,
+		adsDepthLimit:  recursionLimit(opts.adsDepthLimit),
+		firstSyncDepth: opts.firstSyncDepth,
+		segDepthLimit:  opts.segDepthLimit,
 
 		selectorOne: ssb.ExploreRecursive(selector.RecursionLimitDepth(0), all).Node(),
 		selectorAll: ssb.ExploreRecursive(selector.RecursionLimitNone(), all).Node(),
@@ -463,6 +465,8 @@ func (s *Subscriber) SyncAdChain(ctx context.Context, peerInfo peer.AddrInfo, op
 			log.Infow("cid to sync to is the stop node. Nothing to do")
 			return nextCid, nil
 		}
+	} else if s.firstSyncDepth != 0 && opts.depthLimit == 0 {
+		depthLimit = recursionLimit(s.firstSyncDepth)
 	}
 
 	log = log.With("cid", nextCid)
@@ -842,6 +846,7 @@ func (h *handler) asyncSyncAdChain(ctx context.Context) {
 		return
 	}
 
+	adsDepthLimit := h.subscriber.adsDepthLimit
 	nextCid := amsg.Cid
 	latestSyncLink := h.subscriber.GetLatestSync(h.peerID)
 	var stopAtCid cid.Cid
@@ -851,9 +856,12 @@ func (h *handler) asyncSyncAdChain(ctx context.Context) {
 			log.Infow("CID to sync to is the stop node. Nothing to do.", "peer", h.peerID)
 			return
 		}
+	} else if h.subscriber.firstSyncDepth != 0 {
+		// If nothing synced yet, use first sync depth if configured.
+		adsDepthLimit = recursionLimit(h.subscriber.firstSyncDepth)
 	}
 
-	sel := ExploreRecursiveWithStopNode(h.subscriber.adsDepthLimit, h.subscriber.adsSelectorSeq, latestSyncLink)
+	sel := ExploreRecursiveWithStopNode(adsDepthLimit, h.subscriber.adsSelectorSeq, latestSyncLink)
 	syncCount, err := h.handle(ctx, nextCid, sel, syncer, h.subscriber.generalBlockHook, h.subscriber.segDepthLimit, stopAtCid)
 	if err != nil {
 		// Failed to handle the sync, so allow another announce for the same CID.


### PR DESCRIPTION
There is now a dagsync.Subscriber option to configure the first sync depth for a new provider.