### PR TITLE
Check for no addrs before constructing syncer

### DIFF
--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -406,6 +406,7 @@ func (s *Subscriber) SyncAdChain(ctx context.Context, peerInfo peer.AddrInfo, op
 		opts.blockHook = s.generalBlockHook
 	}
 
+	peerInfo = mautil.CleanPeerAddrInfo(peerInfo)
 	var err error
 	peerInfo, err = removeIDFromAddrs(peerInfo)
 	if err != nil {
@@ -553,6 +554,7 @@ func (s *Subscriber) syncEntries(ctx context.Context, peerInfo peer.AddrInfo, en
 	s.expSyncMutex.Unlock()
 	defer s.expSyncWG.Done()
 
+	peerInfo = mautil.CleanPeerAddrInfo(peerInfo)
 	peerInfo, err := removeIDFromAddrs(peerInfo)
 	if err != nil {
 		return err

--- a/mautil/mautil.go
+++ b/mautil/mautil.go
@@ -80,3 +80,15 @@ func StringsToMultiaddrs(addrs []string) ([]multiaddr.Multiaddr, error) {
 	}
 	return maddrs, lastErr
 }
+
+func CleanPeerAddrInfo(target peer.AddrInfo) peer.AddrInfo {
+	for i := 0; i < len(target.Addrs); {
+		if target.Addrs[i] == nil {
+			target.Addrs[i] = target.Addrs[len(target.Addrs)-1]
+			target.Addrs = target.Addrs[:len(target.Addrs)-1]
+			continue
+		}
+		i++
+	}
+	return target
+}


### PR DESCRIPTION
Assert that a there are addresses associated to a remote peer before constructing a syncer.