### PR TITLE
Fix empty address check in v0.5.11

### DIFF
--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -415,6 +415,7 @@ func (s *Subscriber) SyncAdChain(ctx context.Context, peerInfo peer.AddrInfo, op
 		opts.blockHook = s.generalBlockHook
 	}
 
+	peerInfo = mautil.CleanPeerAddrInfo(peerInfo)
 	var err error
 	peerInfo, err = removeIDFromAddrs(peerInfo)
 	if err != nil {
@@ -563,6 +564,7 @@ func (s *Subscriber) syncEntries(ctx context.Context, peerInfo peer.AddrInfo, en
 	s.expSyncMutex.Unlock()
 	defer s.expSyncWG.Done()
 
+	peerInfo = mautil.CleanPeerAddrInfo(peerInfo)
 	peerInfo, err := removeIDFromAddrs(peerInfo)
 	if err != nil {
 		return err

--- a/mautil/mautil.go
+++ b/mautil/mautil.go
@@ -80,3 +80,15 @@ func StringsToMultiaddrs(addrs []string) ([]multiaddr.Multiaddr, error) {
 	}
 	return maddrs, lastErr
 }
+
+func CleanPeerAddrInfo(target peer.AddrInfo) peer.AddrInfo {
+	for i := 0; i < len(target.Addrs); {
+		if target.Addrs[i] == nil {
+			target.Addrs[i] = target.Addrs[len(target.Addrs)-1]
+			target.Addrs = target.Addrs[:len(target.Addrs)-1]
+			continue
+		}
+		i++
+	}
+	return target
+}


### PR DESCRIPTION
Check for empty addrs earlier when instantiating syncer.

Patch fix for v0.5.11.

See #155 for fix on `main`.