### PR TITLE
Add a sequence number to advertisements

### DIFF
--- a/ingest/schema/envelope_test.go
+++ b/ingest/schema/envelope_test.go
@@ -51,7 +51,7 @@ func testSignAndVerify(t *testing.T, signer func(*stischema.Advertisement, crypt
 	require.NoError(t, err)
 	elnk, err := lsys.Store(ipld.LinkContext{}, stischema.Linkproto, node)
 	require.NoError(t, err)
-
+	seq := uint64(123)
 	adv := stischema.Advertisement{
 		Provider: "12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA",
 		Addresses: []string{
@@ -60,6 +60,7 @@ func testSignAndVerify(t *testing.T, signer func(*stischema.Advertisement, crypt
 		Entries:   elnk,
 		ContextID: []byte("test-context-id"),
 		Metadata:  []byte("test-metadata"),
+		SeqNum:    &seq,
 	}
 	err = signer(&adv, priv)
 	require.NoError(t, err)

--- a/ingest/schema/schema.ipldsch
+++ b/ingest/schema/schema.ipldsch
@@ -64,6 +64,8 @@ type Advertisement struct {
     Metadata Bytes
     # IsRm specifies whether this advertisement represents the content are no longer retrievalbe fom the provider.
     IsRm Bool
+    # SeqNum is a monotonically increasing sequence number that gives the advertisement's distance in the chain.
+    SeqNum optional Int
     # ExtendedProvider might optionally specify a set of providers where the ad entries are available from. 
     # See: https://github.com/ipni/storetheindex/blob/main/doc/ingest.md#extendedprovider
     ExtendedProvider optional ExtendedProvider

--- a/ingest/schema/types.go
+++ b/ingest/schema/types.go
@@ -40,6 +40,7 @@ type (
 		ContextID        []byte
 		Metadata         []byte
 		IsRm             bool
+		SeqNum           *uint64
 		ExtendedProvider *ExtendedProvider
 	}
 	EntryChunk struct {
@@ -98,6 +99,13 @@ func (a Advertisement) PreviousCid() cid.Cid {
 		return cid.Undef
 	}
 	return a.PreviousID.(cidlink.Link).Cid
+}
+
+func (a Advertisement) Sequence() uint64 {
+	if a.SeqNum == nil {
+		return 0
+	}
+	return uint64(*a.SeqNum)
 }
 
 func (a Advertisement) Validate() error {

--- a/ingest/schema/types_test.go
+++ b/ingest/schema/types_test.go
@@ -269,6 +269,7 @@ func Test_LinkLoadNoEntries(t *testing.T) {
 func generateAdvertisement() *stischema.Advertisement {
 	mhs := test.RandomMultihashes(7)
 	prev := ipld.Link(cidlink.Link{Cid: cid.NewCidV1(cid.Raw, mhs[0])})
+	seq := uint64(54321)
 	return &stischema.Advertisement{
 		PreviousID: prev,
 		Provider:   mhs[1].String(),
@@ -280,6 +281,7 @@ func generateAdvertisement() *stischema.Advertisement {
 		Metadata:  mhs[5],
 		Signature: mhs[6],
 		IsRm:      false,
+		SeqNum:    &seq,
 	}
 }
 


### PR DESCRIPTION
The sequence number is optional to allow backwards compatability with previous existing advertisements that do not have a sequence number.