### PR TITLE
Reuse sync client5x

### DIFF
--- a/dagsync/dtsync/sync.go
+++ b/dagsync/dtsync/sync.go
@@ -102,9 +102,9 @@ func (s *Sync) Close() error {
 }
 
 // NewSyncer creates a new Syncer to use for a single sync operation against a peer.
-func (s *Sync) NewSyncer(peerID peer.ID, topicName string) *Syncer {
+func (s *Sync) NewSyncer(peerInfo peer.AddrInfo, topicName string) *Syncer {
 	return &Syncer{
-		peerID:    peerID,
+		peerInfo:  peerInfo,
 		sync:      s,
 		topicName: topicName,
 		ls:        s.ls,

--- a/dagsync/dtsync/syncer_test.go
+++ b/dagsync/dtsync/syncer_test.go
@@ -81,7 +81,11 @@ func TestDTSync_CallsBlockHookWhenCIDsAreFullyFoundLocally(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, subject.Close()) })
 
 	// Sync l3 from the publisher.
-	syncer := subject.NewSyncer(pubh.ID(), topic)
+	pubInfo := peer.AddrInfo{
+		ID:    pubh.ID(),
+		Addrs: pubh.Addrs(),
+	}
+	syncer := subject.NewSyncer(pubInfo, topic)
 	require.NoError(t, syncer.Sync(ctx, l3.(cidlink.Link).Cid, selectorparse.CommonSelector_ExploreAllRecursively))
 
 	// Assert there are three synced CIDs.
@@ -175,7 +179,11 @@ func TestDTSync_CallsBlockHookWhenCIDsArePartiallyFoundLocally(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, subject.Close()) })
 
 	// Sync l3 from the publisher.
-	syncer := subject.NewSyncer(pubh.ID(), topic)
+	pubInfo := peer.AddrInfo{
+		ID:    pubh.ID(),
+		Addrs: pubh.Addrs(),
+	}
+	syncer := subject.NewSyncer(pubInfo, topic)
 	require.NoError(t, syncer.Sync(ctx, l3.(cidlink.Link).Cid, selectorparse.CommonSelector_ExploreAllRecursively))
 
 	// Assert there are three synced CIDs.

--- a/dagsync/interface.go
+++ b/dagsync/interface.go
@@ -27,4 +27,5 @@ type Publisher interface {
 type Syncer interface {
 	GetHead(context.Context) (cid.Cid, error)
 	Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
+	SameAddrs([]multiaddr.Multiaddr) bool
 }

--- a/dagsync/ipnisync/sync.go
+++ b/dagsync/ipnisync/sync.go
@@ -27,6 +27,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2phttp "github.com/libp2p/go-libp2p/p2p/http"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 )
 
@@ -50,11 +51,11 @@ type Sync struct {
 
 // Syncer provides sync functionality for a single sync with a peer.
 type Syncer struct {
-	client  *http.Client
-	peerID  peer.ID
-	rootURL url.URL
-	urls    []*url.URL
-	sync    *Sync
+	client   *http.Client
+	peerInfo peer.AddrInfo
+	rootURL  url.URL
+	urls     []*url.URL
+	sync     *Sync
 
 	// For legacy HTTP and external server support without IPNI path.
 	noPath    bool
@@ -173,11 +174,11 @@ func (s *Sync) NewSyncer(peerInfo peer.AddrInfo) (*Syncer, error) {
 	}
 
 	return &Syncer{
-		client:  httpClient,
-		peerID:  peerInfo.ID,
-		rootURL: *urls[0],
-		urls:    urls[1:],
-		sync:    s,
+		client:   httpClient,
+		peerInfo: peerInfo,
+		rootURL:  *urls[0],
+		urls:     urls[1:],
+		sync:     s,
 
 		plainHTTP: plainHTTP,
 	}, nil
@@ -206,10 +207,10 @@ func (s *Syncer) GetHead(ctx context.Context) (cid.Cid, error) {
 	if err != nil {
 		return cid.Undef, err
 	}
-	if s.peerID == "" {
+	if s.peerInfo.ID == "" {
 		log.Warn("Cannot verify publisher signature without peer ID")
-	} else if signerID != s.peerID {
-		return cid.Undef, fmt.Errorf("found head signed by an unexpected peer, peerID: %s, signed-by: %s", s.peerID.String(), signerID.String())
+	} else if signerID != s.peerInfo.ID {
+		return cid.Undef, fmt.Errorf("found head signed by an unexpected peer, peerID: %s, signed-by: %s", s.peerInfo.ID.String(), signerID.String())
 	}
 
 	// TODO: Check that the returned topic, if any, matches the expected topic.
@@ -220,6 +221,10 @@ func (s *Syncer) GetHead(ctx context.Context) (cid.Cid, error) {
 	//}
 
 	return signedHead.Head.(cidlink.Link).Cid, nil
+}
+
+func (s *Syncer) SameAddrs(maddrs []multiaddr.Multiaddr) bool {
+	return mautil.MultiaddrsEqual(s.peerInfo.Addrs, maddrs)
 }
 
 // Sync syncs the peer's advertisement chain or entries chain.
@@ -244,7 +249,7 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 	// hook at the end when we no longer care what it does with the blocks.
 	if s.sync.blockHook != nil {
 		for _, c := range cids {
-			s.sync.blockHook(s.peerID, c)
+			s.sync.blockHook(s.peerInfo.ID, c)
 		}
 	}
 
@@ -322,7 +327,7 @@ retry:
 			goto nextURL
 		}
 		if !doneRetry && errors.Is(err, network.ErrReset) {
-			log.Errorw("stream reset err, retrying", "publisher", s.peerID, "url", fetchURL.String())
+			log.Errorw("stream reset err, retrying", "publisher", s.peerInfo.ID, "url", fetchURL.String())
 			// Only retry the same fetch once.
 			doneRetry = true
 			goto retry

--- a/mautil/mautil_test.go
+++ b/mautil/mautil_test.go
@@ -125,3 +125,54 @@ func TestCleanPeerAddrInfo(t *testing.T) {
 		require.ElementsMatch(t, goodAddrs, cleaned.Addrs)
 	})
 }
+
+func TestMultiaddrsEqual(t *testing.T) {
+	maddrs, err := mautil.StringsToMultiaddrs([]string{
+		"/ip4/11.0.0.0/tcp/80/http",
+		"/ip6/fc00::/tcp/1717",
+		"/ip6/fe00::/tcp/8080/https",
+		"/dns4/example.net/tcp/1234",
+	})
+	require.NoError(t, err)
+	rev := make([]multiaddr.Multiaddr, len(maddrs))
+	j := len(maddrs) - 1
+	for i := 0; i <= j; i++ {
+		rev[i] = maddrs[j-i]
+	}
+	m1 := make([]multiaddr.Multiaddr, len(maddrs))
+	m2 := make([]multiaddr.Multiaddr, len(maddrs))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1, m2))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.Truef(t, mautil.MultiaddrsEqual(m1[1:], m2[:len(m2)-1]), "m1=%v, m2=%v", m1[1:], m2[:len(m2)-1])
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1[2:3], m2[1:2]))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1[:0], m2[:0]))
+
+	require.True(t, mautil.MultiaddrsEqual(nil, nil))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1[:0], nil))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.False(t, mautil.MultiaddrsEqual(m1[1:], m2[1:]))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.False(t, mautil.MultiaddrsEqual(m1, m2[:len(m2)-1]))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.False(t, mautil.MultiaddrsEqual(m1[:1], m2[:1]))
+}


### PR DESCRIPTION
Reuse sync client unless peer addresses changed

A new sync client was being created for each advertisement that entries were synced for. This was not a problem for plain HTTP since the HTTP client was reused. However for libp2phttp a new namespaced client was created each time. This established another connection between the indexer and the index-provider. Long advertisement chains could eat up all network resources and cause indexing to grind to a halt.

This PR fixes this by reusing each index-provider's sync client to sync advertisement chains and entries chains. A sync client is kept with the index-provider dagsync subscription handler. A new sync client is created only if there is no sync client yet or if the index-provider's addresses have changed.