### PR TITLE
Reuse sync client unless peer addresses changed

### DIFF
--- a/dagsync/interface.go
+++ b/dagsync/interface.go
@@ -27,4 +27,5 @@ type Publisher interface {
 type Syncer interface {
 	GetHead(context.Context) (cid.Cid, error)
 	Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
+	SameAddrs([]multiaddr.Multiaddr) bool
 }

--- a/mautil/mautil_test.go
+++ b/mautil/mautil_test.go
@@ -125,3 +125,54 @@ func TestCleanPeerAddrInfo(t *testing.T) {
 		require.ElementsMatch(t, goodAddrs, cleaned.Addrs)
 	})
 }
+
+func TestMultiaddrsEqual(t *testing.T) {
+	maddrs, err := mautil.StringsToMultiaddrs([]string{
+		"/ip4/11.0.0.0/tcp/80/http",
+		"/ip6/fc00::/tcp/1717",
+		"/ip6/fe00::/tcp/8080/https",
+		"/dns4/example.net/tcp/1234",
+	})
+	require.NoError(t, err)
+	rev := make([]multiaddr.Multiaddr, len(maddrs))
+	j := len(maddrs) - 1
+	for i := 0; i <= j; i++ {
+		rev[i] = maddrs[j-i]
+	}
+	m1 := make([]multiaddr.Multiaddr, len(maddrs))
+	m2 := make([]multiaddr.Multiaddr, len(maddrs))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1, m2))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.Truef(t, mautil.MultiaddrsEqual(m1[1:], m2[:len(m2)-1]), "m1=%v, m2=%v", m1[1:], m2[:len(m2)-1])
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1[2:3], m2[1:2]))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1[:0], m2[:0]))
+
+	require.True(t, mautil.MultiaddrsEqual(nil, nil))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.True(t, mautil.MultiaddrsEqual(m1[:0], nil))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.False(t, mautil.MultiaddrsEqual(m1[1:], m2[1:]))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.False(t, mautil.MultiaddrsEqual(m1, m2[:len(m2)-1]))
+
+	copy(m1, maddrs)
+	copy(m2, rev)
+	require.False(t, mautil.MultiaddrsEqual(m1[:1], m2[:1]))
+}


### PR DESCRIPTION
A new sync client was being created for each advertisement that entries were synced for. This was not a problem for plain HTTP since the HTTP client was reused. However for libp2phttp a new namespaced client was created each time. This established another connection between the indexer and the index-provider. Long advertisement chains could eat up all network resources and cause indexing to grind to a halt.

This PR fixes this by reusing each index-provider's sync client to sync advertisement chains and entries chains. A sync client is kept with the index-provider dagsync subscription handler. A new sync client is created only if there is no sync client yet or if the index-provider's addresses have changed.