### PR TITLE
Include optional Ipni-Cid-Schema-Type HTTP header

### DIFF
--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -34,7 +34,7 @@ func TestAnnounceReplace(t *testing.T) {
 	}
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstLnkS, dagsync.RecvAnnounce(testTopic),
-		dagsync.BlockHook(blockHook))
+		dagsync.BlockHook(blockHook), dagsync.WithCidSchemaHint(false))
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -377,7 +377,7 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching, allowPeer f
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstLnkS,
+	sub, err := dagsync.NewSubscriber(dstHost, dstLnkS, dagsync.WithCidSchemaHint(false),
 		dagsync.RecvAnnounce(testTopic, announce.WithTopic(topics[1]), announce.WithAllowPeer(allowPeer)))
 	require.NoError(t, err)
 

--- a/dagsync/ipnisync/cid_schema_hint.go
+++ b/dagsync/ipnisync/cid_schema_hint.go
@@ -1,24 +1,77 @@
 package ipnisync
 
+import (
+	"context"
+	"errors"
+)
+
 const (
 	// CidSchemaHeader is the HTTP header used as an optional hint about the
 	// type of data requested by a CID.
 	CidSchemaHeader = "Ipni-Cid-Schema-Type"
-	// CidSchemaAd is a value for the CidSchemaHeader specifying advertiesement
-	// data is being requested.
-	CidSchemaAd = "advertisement"
+	// CidSchemaAdvertisement is a value for the CidSchemaHeader specifying
+	// advertiesement data is being requested. Referrs to Advertisement in
+	// https://github.com/ipni/go-libipni/blob/main/ingest/schema/schema.ipldsch
+	CidSchemaAdvertisement = "Advertisement"
 	// CidSchemaEntries is a value for the CidSchemaHeader specifying
 	// advertisement entries (multihash chunks) data is being requested.
-	CidSchemaEntries = "entries"
+	// Referrs to Entry chunk in
+	// https://github.com/ipni/go-libipni/blob/main/ingest/schema/schema.ipldsch
+	CidSchemaEntryChunk = "EntryChunk"
 )
+
+var ErrUnknownCidSchema = errors.New("unknown cid schema type value")
 
 // cidSchemaTypeKey is the type used for the key of CidSchemaHeader when set as
 // a context value.
 type cidSchemaTypeCtxKey string
 
-// CidSchemaCtxKey is used as the key when creating a context with a value or extracting the cid schema from a context. Examples:
+// cidSchemaCtxKey is used to get the key used to store or extract the cid
+// schema value in a context.
+const cidSchemaCtxKey cidSchemaTypeCtxKey = CidSchemaHeader
+
+// CidSchemaFromCtx extracts the CID schema name from the context. If the
+// scheam value is not set, then returns "". If the schema value is set, but is
+// not recognized, then ErrUnknownCidSchema is returned along with the value.
 //
-//	ctx := context.WithValue(ctx, CidSchemaCtxKey, CidSchemaAd)
+// Returning unrecognized values with an  error allows consumers to retrieved
+// newer values that are not recognized by an older version of this library.
+func CidSchemaFromCtx(ctx context.Context) (string, error) {
+	if ctx == nil {
+		return "", nil
+	}
+	cidSchemaType, ok := ctx.Value(cidSchemaCtxKey).(string)
+	if !ok {
+		return "", nil
+	}
+
+	var err error
+	switch cidSchemaType {
+	case CidSchemaAdvertisement, CidSchemaEntryChunk:
+	default:
+		err = ErrUnknownCidSchema
+	}
+	return cidSchemaType, err
+}
+
+// CtxWithCidSchema creates a derived context that has the specified value for
+// the CID schema type.
 //
-//	cidSchemaType, ok := ctx.Value(CidSchemaCtxKey).(string)
-const CidSchemaCtxKey cidSchemaTypeCtxKey = CidSchemaHeader
+// Setting an unrecognized value, even when an error is retruned, allows
+// producers to set context values that are not recognized by an older version
+// of this library.
+func CtxWithCidSchema(ctx context.Context, cidSchemaType string) (context.Context, error) {
+	if cidSchemaType == "" {
+		return ctx, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var err error
+	switch cidSchemaType {
+	case CidSchemaAdvertisement, CidSchemaEntryChunk:
+	default:
+		err = ErrUnknownCidSchema
+	}
+	return context.WithValue(ctx, cidSchemaCtxKey, cidSchemaType), err
+}

--- a/dagsync/ipnisync/cid_schema_hint.go
+++ b/dagsync/ipnisync/cid_schema_hint.go
@@ -37,9 +37,6 @@ const cidSchemaCtxKey cidSchemaTypeCtxKey = CidSchemaHeader
 // Returning unrecognized values with an  error allows consumers to retrieved
 // newer values that are not recognized by an older version of this library.
 func CidSchemaFromCtx(ctx context.Context) (string, error) {
-	if ctx == nil {
-		return "", nil
-	}
 	cidSchemaType, ok := ctx.Value(cidSchemaCtxKey).(string)
 	if !ok {
 		return "", nil
@@ -63,9 +60,6 @@ func CidSchemaFromCtx(ctx context.Context) (string, error) {
 func CtxWithCidSchema(ctx context.Context, cidSchemaType string) (context.Context, error) {
 	if cidSchemaType == "" {
 		return ctx, nil
-	}
-	if ctx == nil {
-		ctx = context.Background()
 	}
 	var err error
 	switch cidSchemaType {

--- a/dagsync/ipnisync/cid_schema_hint.go
+++ b/dagsync/ipnisync/cid_schema_hint.go
@@ -1,0 +1,24 @@
+package ipnisync
+
+const (
+	// CidSchemaHeader is the HTTP header used as an optional hint about the
+	// type of data requested by a CID.
+	CidSchemaHeader = "Ipni-Cid-Schema-Type"
+	// CidSchemaAd is a value for the CidSchemaHeader specifying advertiesement
+	// data is being requested.
+	CidSchemaAd = "advertisement"
+	// CidSchemaEntries is a value for the CidSchemaHeader specifying
+	// advertisement entries (multihash chunks) data is being requested.
+	CidSchemaEntries = "entries"
+)
+
+// cidSchemaTypeKey is the type used for the key of CidSchemaHeader when set as
+// a context value.
+type cidSchemaTypeCtxKey string
+
+// CidSchemaCtxKey is used as the key when creating a context with a value or extracting the cid schema from a context. Examples:
+//
+//	ctx := context.WithValue(ctx, CidSchemaCtxKey, CidSchemaAd)
+//
+//	cidSchemaType, ok := ctx.Value(CidSchemaCtxKey).(string)
+const CidSchemaCtxKey cidSchemaTypeCtxKey = CidSchemaHeader

--- a/dagsync/ipnisync/cid_schema_hint_test.go
+++ b/dagsync/ipnisync/cid_schema_hint_test.go
@@ -9,12 +9,8 @@ import (
 )
 
 func TestCtxWithCidSchema(t *testing.T) {
-	ctx, err := ipnisync.CtxWithCidSchema(nil, "")
-	require.NoError(t, err)
-	require.Nil(t, ctx)
-
 	ctxOrig := context.Background()
-	ctx, err = ipnisync.CtxWithCidSchema(ctxOrig, "")
+	ctx, err := ipnisync.CtxWithCidSchema(ctxOrig, "")
 	require.NoError(t, err)
 	require.Equal(t, ctxOrig, ctx)
 
@@ -26,7 +22,7 @@ func TestCtxWithCidSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ipnisync.CidSchemaAdvertisement, value)
 
-	ctx, err = ipnisync.CtxWithCidSchema(nil, ipnisync.CidSchemaEntryChunk)
+	ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaEntryChunk)
 	require.NoError(t, err)
 	value, err = ipnisync.CidSchemaFromCtx(ctx)
 	require.NoError(t, err)

--- a/dagsync/ipnisync/cid_schema_hint_test.go
+++ b/dagsync/ipnisync/cid_schema_hint_test.go
@@ -1,0 +1,50 @@
+package ipnisync_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipni/go-libipni/dagsync/ipnisync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtxWithCidSchema(t *testing.T) {
+	ctx, err := ipnisync.CtxWithCidSchema(nil, "")
+	require.NoError(t, err)
+	require.Nil(t, ctx)
+
+	ctxOrig := context.Background()
+	ctx, err = ipnisync.CtxWithCidSchema(ctxOrig, "")
+	require.NoError(t, err)
+	require.Equal(t, ctxOrig, ctx)
+
+	ctx, err = ipnisync.CtxWithCidSchema(ctxOrig, ipnisync.CidSchemaAdvertisement)
+	require.NoError(t, err)
+	require.NotEqual(t, ctxOrig, ctx)
+
+	value, err := ipnisync.CidSchemaFromCtx(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ipnisync.CidSchemaAdvertisement, value)
+
+	ctx, err = ipnisync.CtxWithCidSchema(nil, ipnisync.CidSchemaEntryChunk)
+	require.NoError(t, err)
+	value, err = ipnisync.CidSchemaFromCtx(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ipnisync.CidSchemaEntryChunk, value)
+
+	value, err = ipnisync.CidSchemaFromCtx(ctxOrig)
+	require.NoError(t, err)
+	require.Empty(t, value)
+
+	const unknownVal = "unknown"
+
+	// Setting unknown value returns error as well as context with value.
+	ctx, err = ipnisync.CtxWithCidSchema(ctxOrig, unknownVal)
+	require.ErrorIs(t, err, ipnisync.ErrUnknownCidSchema)
+	require.NotNil(t, ctxOrig, ctx)
+
+	// Getting unknown value returns error as well as value.
+	value, err = ipnisync.CidSchemaFromCtx(ctx)
+	require.ErrorIs(t, err, ipnisync.ErrUnknownCidSchema)
+	require.Equal(t, unknownVal, value)
+}

--- a/dagsync/ipnisync/publisher.go
+++ b/dagsync/ipnisync/publisher.go
@@ -1,6 +1,7 @@
 package ipnisync
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -229,7 +230,7 @@ func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reqType := r.Header.Get(CidSchemaHeader)
 	if reqType != "" {
 		log.Debug("sync request has cid schema type hint", "hint", reqType)
-		ipldCtx.Ctx, err = CtxWithCidSchema(ipldCtx.Ctx, reqType)
+		ipldCtx.Ctx, err = CtxWithCidSchema(context.Background(), reqType)
 		if err != nil {
 			// Log warning about unknown cid schema type, but continue on since
 			// the linksystem might recognize it.
@@ -238,7 +239,6 @@ func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var ipldProto ipldmodel.NodePrototype
-
 	switch reqType {
 	case CidSchemaAdvertisement:
 		ipldProto = schema.AdvertisementPrototype
@@ -247,8 +247,6 @@ func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		ipldProto = basicnode.Prototype.Any
 	}
-
-	//ipldProto = basicnode.Prototype.Any
 
 	item, err := p.lsys.Load(ipldCtx, cidlink.Link{Cid: c}, ipldProto)
 	if err != nil {

--- a/dagsync/ipnisync/publisher.go
+++ b/dagsync/ipnisync/publisher.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
-	ipldmodel "github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	headschema "github.com/ipni/go-libipni/dagsync/ipnisync/head"
@@ -238,7 +238,7 @@ func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var ipldProto ipldmodel.NodePrototype
+	var ipldProto datamodel.NodePrototype
 	switch reqType {
 	case CidSchemaAdvertisement:
 		ipldProto = schema.AdvertisementPrototype

--- a/dagsync/ipnisync/sync.go
+++ b/dagsync/ipnisync/sync.go
@@ -227,13 +227,9 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 	}
 
 	// Check for valid cid schema type if set.
-	cidSchemaType, ok := ctx.Value(CidSchemaCtxKey).(string)
-	if ok {
-		switch cidSchemaType {
-		case CidSchemaAd, CidSchemaEntries:
-		default:
-			return fmt.Errorf("invalid cid schema type value: %s", cidSchemaType)
-		}
+	_, err = CidSchemaFromCtx(ctx)
+	if err != nil {
+		return err
 	}
 
 	cids, err := s.walkFetch(ctx, nextCid, xsel)
@@ -317,9 +313,9 @@ retry:
 		return err
 	}
 
-	// Value already checked in Sync.
-	reqType, ok := ctx.Value(CidSchemaCtxKey).(string)
-	if ok {
+	// Error already checked in Sync.
+	reqType, _ := CidSchemaFromCtx(ctx)
+	if reqType != "" {
 		req.Header.Set(CidSchemaHeader, reqType)
 	}
 

--- a/dagsync/ipnisync/sync.go
+++ b/dagsync/ipnisync/sync.go
@@ -17,7 +17,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
-	ipldmodel "github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal"
@@ -234,7 +233,7 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 		return err
 	}
 
-	var ipldProto ipldmodel.NodePrototype
+	var ipldProto datamodel.NodePrototype
 	switch reqType {
 	case CidSchemaAdvertisement:
 		ipldProto = schema.AdvertisementPrototype
@@ -270,7 +269,7 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 // walkFetch is run by a traversal of the selector. For each block that the
 // selector walks over, walkFetch will look to see if it can find it in the
 // local data store. If it cannot, it will then go and get it over HTTP.
-func (s *Syncer) walkFetch(ctx context.Context, rootCid cid.Cid, sel selector.Selector, ipldProto ipldmodel.NodePrototype) ([]cid.Cid, error) {
+func (s *Syncer) walkFetch(ctx context.Context, rootCid cid.Cid, sel selector.Selector, ipldProto datamodel.NodePrototype) ([]cid.Cid, error) {
 	// Track the order of cids seen during traversal so that the block hook
 	// function gets called in the same order.
 	var traversalOrder []cid.Cid
@@ -386,7 +385,7 @@ retry:
 }
 
 // fetchBlock fetches an item into the datastore at c if not locally available.
-func (s *Syncer) fetchBlock(ctx context.Context, c cid.Cid, ipldProto ipldmodel.NodePrototype) error {
+func (s *Syncer) fetchBlock(ctx context.Context, c cid.Cid, ipldProto datamodel.NodePrototype) error {
 	n, err := s.sync.lsys.Load(ipld.LinkContext{Ctx: ctx}, cidlink.Link{Cid: c}, ipldProto)
 	// node is already present.
 	if n != nil && err == nil {

--- a/dagsync/option.go
+++ b/dagsync/option.go
@@ -48,6 +48,7 @@ type config struct {
 	firstSyncDepth    int64
 	segDepthLimit     int64
 
+	cidSchemaHint   bool
 	strictAdsSelSeq bool
 
 	httpTimeout      time.Duration
@@ -66,6 +67,7 @@ func getOpts(opts []Option) (config, error) {
 		httpTimeout:     defaultHttpTimeout,
 		idleHandlerTTL:  defaultIdleHandlerTTL,
 		segDepthLimit:   defaultSegDepthLimit,
+		cidSchemaHint:   true,
 		strictAdsSelSeq: true,
 	}
 
@@ -337,5 +339,12 @@ func MakeGeneralBlockHook(prevAdCid func(adCid cid.Cid) (cid.Cid, error)) BlockH
 		} else {
 			actions.SetNextSyncCid(prevCid)
 		}
+	}
+}
+
+func WithCidSchemaHint(enable bool) Option {
+	return func(c *config) error {
+		c.cidSchemaHint = enable
+		return nil
 	}
 }

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -488,7 +488,10 @@ func (s *Subscriber) SyncAdChain(ctx context.Context, peerInfo peer.AddrInfo, op
 
 	sel := ExploreRecursiveWithStopNode(depthLimit, s.adsSelectorSeq, stopLnk)
 
-	ctx = context.WithValue(ctx, ipnisync.CidSchemaCtxKey, ipnisync.CidSchemaAd)
+	ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaAdvertisement)
+	if err != nil {
+		panic(err.Error())
+	}
 	syncCount, err := hnd.handle(ctx, nextCid, sel, syncer, opts.blockHook, segdl, stopAtCid)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("sync handler failed: %w", err)
@@ -572,7 +575,10 @@ func (s *Subscriber) syncEntries(ctx context.Context, peerInfo peer.AddrInfo, en
 
 	log.Debugw("Start entries sync", "peer", peerInfo.ID, "cid", entCid)
 
-	ctx = context.WithValue(ctx, ipnisync.CidSchemaCtxKey, ipnisync.CidSchemaEntries)
+	ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaEntryChunk)
+	if err != nil {
+		panic(err.Error())
+	}
 	_, err = hnd.handle(ctx, entCid, sel, syncer, bh, segdl, cid.Undef)
 	if err != nil {
 		return fmt.Errorf("sync handler failed: %w", err)
@@ -874,7 +880,10 @@ func (h *handler) asyncSyncAdChain(ctx context.Context) {
 		return
 	}
 
-	ctx = context.WithValue(ctx, ipnisync.CidSchemaCtxKey, ipnisync.CidSchemaAd)
+	ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaAdvertisement)
+	if err != nil {
+		panic(err.Error())
+	}
 	sel := ExploreRecursiveWithStopNode(adsDepthLimit, h.subscriber.adsSelectorSeq, latestSyncLink)
 	syncCount, err := h.handle(ctx, nextCid, sel, syncer, h.subscriber.generalBlockHook, h.subscriber.segDepthLimit, stopAtCid)
 	if err != nil {

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -118,6 +118,10 @@ type Subscriber struct {
 	// specifies the selection sequence itself.
 	adsSelectorSeq ipld.Node
 
+	// cidSchemaHint enables sending the cid schema type hint as
+	// an HTTP header in sync requests.
+	cidSchemaHint bool
+
 	// selectorOne selects one multihash entries or HAMT block.
 	selectorOne ipld.Node
 	// selectorAll selects all multihash HAMT blocks.
@@ -236,6 +240,8 @@ func NewSubscriber(host host.Host, lsys ipld.LinkSystem, options ...Option) (*Su
 			ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
 				efsb.Insert("Next", ssb.ExploreRecursiveEdge()) // Next field in EntryChunk
 			})).Node(),
+
+		cidSchemaHint: opts.cidSchemaHint,
 	}
 
 	if opts.strictAdsSelSeq {
@@ -244,6 +250,7 @@ func NewSubscriber(host host.Host, lsys ipld.LinkSystem, options ...Option) (*Su
 		}).Node()
 	} else {
 		s.adsSelectorSeq = ssb.ExploreAll(ssb.ExploreRecursiveEdge()).Node()
+		s.cidSchemaHint = false
 	}
 
 	if opts.hasRcvr {
@@ -488,9 +495,11 @@ func (s *Subscriber) SyncAdChain(ctx context.Context, peerInfo peer.AddrInfo, op
 
 	sel := ExploreRecursiveWithStopNode(depthLimit, s.adsSelectorSeq, stopLnk)
 
-	ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaAdvertisement)
-	if err != nil {
-		panic(err.Error())
+	if s.cidSchemaHint {
+		ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaAdvertisement)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 	syncCount, err := hnd.handle(ctx, nextCid, sel, syncer, opts.blockHook, segdl, stopAtCid)
 	if err != nil {
@@ -575,9 +584,11 @@ func (s *Subscriber) syncEntries(ctx context.Context, peerInfo peer.AddrInfo, en
 
 	log.Debugw("Start entries sync", "peer", peerInfo.ID, "cid", entCid)
 
-	ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaEntryChunk)
-	if err != nil {
-		panic(err.Error())
+	if s.cidSchemaHint {
+		ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaEntryChunk)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 	_, err = hnd.handle(ctx, entCid, sel, syncer, bh, segdl, cid.Undef)
 	if err != nil {
@@ -880,9 +891,11 @@ func (h *handler) asyncSyncAdChain(ctx context.Context) {
 		return
 	}
 
-	ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaAdvertisement)
-	if err != nil {
-		panic(err.Error())
+	if h.subscriber.cidSchemaHint {
+		ctx, err = ipnisync.CtxWithCidSchema(ctx, ipnisync.CidSchemaAdvertisement)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 	sel := ExploreRecursiveWithStopNode(adsDepthLimit, h.subscriber.adsSelectorSeq, latestSyncLink)
 	syncCount, err := h.handle(ctx, nextCid, sel, syncer, h.subscriber.generalBlockHook, h.subscriber.segDepthLimit, stopAtCid)

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -488,6 +488,7 @@ func (s *Subscriber) SyncAdChain(ctx context.Context, peerInfo peer.AddrInfo, op
 
 	sel := ExploreRecursiveWithStopNode(depthLimit, s.adsSelectorSeq, stopLnk)
 
+	ctx = context.WithValue(ctx, ipnisync.CidSchemaCtxKey, ipnisync.CidSchemaAd)
 	syncCount, err := hnd.handle(ctx, nextCid, sel, syncer, opts.blockHook, segdl, stopAtCid)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("sync handler failed: %w", err)
@@ -571,6 +572,7 @@ func (s *Subscriber) syncEntries(ctx context.Context, peerInfo peer.AddrInfo, en
 
 	log.Debugw("Start entries sync", "peer", peerInfo.ID, "cid", entCid)
 
+	ctx = context.WithValue(ctx, ipnisync.CidSchemaCtxKey, ipnisync.CidSchemaEntries)
 	_, err = hnd.handle(ctx, entCid, sel, syncer, bh, segdl, cid.Undef)
 	if err != nil {
 		return fmt.Errorf("sync handler failed: %w", err)
@@ -872,6 +874,7 @@ func (h *handler) asyncSyncAdChain(ctx context.Context) {
 		return
 	}
 
+	ctx = context.WithValue(ctx, ipnisync.CidSchemaCtxKey, ipnisync.CidSchemaAd)
 	sel := ExploreRecursiveWithStopNode(adsDepthLimit, h.subscriber.adsSelectorSeq, latestSyncLink)
 	syncCount, err := h.handle(ctx, nextCid, sel, syncer, h.subscriber.generalBlockHook, h.subscriber.segDepthLimit, stopAtCid)
 	if err != nil {

--- a/dagsync/test/util.go
+++ b/dagsync/test/util.go
@@ -170,8 +170,12 @@ func encode(lsys ipld.LinkSystem, n ipld.Node) (ipld.Node, ipld.Link) {
 
 func MkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 	lsys := cidlink.DefaultLinkSystem()
-	lsys.StorageReadOpener = func(_ ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
-		val, err := ds.Get(context.Background(), datastore.NewKey(lnk.String()))
+	lsys.StorageReadOpener = func(ipldCtx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
+		ctx := ipldCtx.Ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		val, err := ds.Get(ctx, datastore.NewKey(lnk.String()))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This optional header, when present, serves as an indication to advertisement publishers what type of data is being requested and is identified by the CID. This may help some publishers more quickly lookup the data.

The publisher, who receives the Ipni-Cid-Schema-Type HTTP header, does not validate the value, because newer values may need to be received by consumer that is using an older version of library.

Implements fix for https://github.com/ipni/storetheindex/issues/2662