### PR TITLE
Always use basicnode.Prototype.Any as not prototype.

### DIFF
--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -35,8 +35,7 @@ func TestAnnounceReplace(t *testing.T) {
 		blocksSeenByHook[c] = struct{}{}
 	}
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.RecvAnnounce(),
-		dagsync.BlockHook(blockHook), dagsync.WithCidSchemaHint(false))
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.RecvAnnounce(), dagsync.BlockHook(blockHook))
 	require.NoError(t, err)
 	defer sub.Close()
 
@@ -458,7 +457,7 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching, allowPeer f
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
 
-	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, dagsync.WithCidSchemaHint(false),
+	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic,
 		dagsync.RecvAnnounce(announce.WithTopic(topics[1]), announce.WithAllowPeer(allowPeer)))
 	require.NoError(t, err)
 

--- a/dagsync/ipnisync/publisher.go
+++ b/dagsync/ipnisync/publisher.go
@@ -13,11 +13,9 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
-	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	headschema "github.com/ipni/go-libipni/dagsync/ipnisync/head"
-	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/ipni/go-libipni/maurl"
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -229,7 +227,6 @@ func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ipldCtx := ipld.LinkContext{}
 	reqType := r.Header.Get(CidSchemaHeader)
 	if reqType != "" {
-		log.Debug("sync request has cid schema type hint", "hint", reqType)
 		ipldCtx.Ctx, err = CtxWithCidSchema(context.Background(), reqType)
 		if err != nil {
 			// Log warning about unknown cid schema type, but continue on since
@@ -238,17 +235,7 @@ func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var ipldProto datamodel.NodePrototype
-	switch reqType {
-	case CidSchemaAdvertisement:
-		ipldProto = schema.AdvertisementPrototype
-	case CidSchemaEntryChunk:
-		ipldProto = schema.EntryChunkPrototype
-	default:
-		ipldProto = basicnode.Prototype.Any
-	}
-
-	item, err := p.lsys.Load(ipldCtx, cidlink.Link{Cid: c}, ipldProto)
+	item, err := p.lsys.Load(ipldCtx, cidlink.Link{Cid: c}, basicnode.Prototype.Any)
 	if err != nil {
 		if errors.Is(err, ipld.ErrNotExists{}) {
 			http.Error(w, "cid not found", http.StatusNotFound)

--- a/dagsync/ipnisync/sync.go
+++ b/dagsync/ipnisync/sync.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	headschema "github.com/ipni/go-libipni/dagsync/ipnisync/head"
-	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/ipni/go-libipni/maurl"
 	"github.com/ipni/go-libipni/mautil"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -244,22 +243,12 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 	}
 
 	// Check for valid cid schema type if set.
-	reqType, err := CidSchemaFromCtx(ctx)
+	_, err = CidSchemaFromCtx(ctx)
 	if err != nil {
 		return err
 	}
 
-	var ipldProto datamodel.NodePrototype
-	switch reqType {
-	case CidSchemaAdvertisement:
-		ipldProto = schema.AdvertisementPrototype
-	case CidSchemaEntryChunk:
-		ipldProto = schema.EntryChunkPrototype
-	default:
-		ipldProto = basicnode.Prototype.Any
-	}
-
-	cids, err := s.walkFetch(ctx, nextCid, xsel, ipldProto)
+	cids, err := s.walkFetch(ctx, nextCid, xsel)
 	if err != nil {
 		return fmt.Errorf("failed to traverse requested dag: %w", err)
 	}
@@ -285,7 +274,7 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 // walkFetch is run by a traversal of the selector. For each block that the
 // selector walks over, walkFetch will look to see if it can find it in the
 // local data store. If it cannot, it will then go and get it over HTTP.
-func (s *Syncer) walkFetch(ctx context.Context, rootCid cid.Cid, sel selector.Selector, ipldProto datamodel.NodePrototype) ([]cid.Cid, error) {
+func (s *Syncer) walkFetch(ctx context.Context, rootCid cid.Cid, sel selector.Selector) ([]cid.Cid, error) {
 	// Track the order of cids seen during traversal so that the block hook
 	// function gets called in the same order.
 	var traversalOrder []cid.Cid
@@ -296,7 +285,7 @@ func (s *Syncer) walkFetch(ctx context.Context, rootCid cid.Cid, sel selector.Se
 	getMissingLs.StorageReadOpener = func(lc ipld.LinkContext, l ipld.Link) (io.Reader, error) {
 		c := l.(cidlink.Link).Cid
 		// fetchBlock checks if the node is already present in storage.
-		err := s.fetchBlock(ctx, c, ipldProto)
+		err := s.fetchBlock(ctx, c)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch block for cid %s: %w", c, err)
 		}
@@ -318,7 +307,7 @@ func (s *Syncer) walkFetch(ctx context.Context, rootCid cid.Cid, sel selector.Se
 	}
 
 	// get the direct node.
-	rootNode, err := getMissingLs.Load(ipld.LinkContext{Ctx: ctx}, cidlink.Link{Cid: rootCid}, ipldProto)
+	rootNode, err := getMissingLs.Load(ipld.LinkContext{Ctx: ctx}, cidlink.Link{Cid: rootCid}, basicnode.Prototype.Any)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load node for root cid %s: %w", rootCid, err)
 	}
@@ -401,8 +390,8 @@ retry:
 }
 
 // fetchBlock fetches an item into the datastore at c if not locally available.
-func (s *Syncer) fetchBlock(ctx context.Context, c cid.Cid, ipldProto datamodel.NodePrototype) error {
-	n, err := s.sync.lsys.Load(ipld.LinkContext{Ctx: ctx}, cidlink.Link{Cid: c}, ipldProto)
+func (s *Syncer) fetchBlock(ctx context.Context, c cid.Cid) error {
+	n, err := s.sync.lsys.Load(ipld.LinkContext{Ctx: ctx}, cidlink.Link{Cid: c}, basicnode.Prototype.Any)
 	// node is already present.
 	if n != nil && err == nil {
 		return nil

--- a/dagsync/option.go
+++ b/dagsync/option.go
@@ -53,7 +53,6 @@ type config struct {
 	gsMaxInRequests  uint64
 	gsMaxOutRequests uint64
 
-	cidSchemaHint   bool
 	strictAdsSelSeq bool
 
 	httpTimeout      time.Duration
@@ -74,7 +73,6 @@ func getOpts(opts []Option) (config, error) {
 		segDepthLimit:    defaultSegDepthLimit,
 		gsMaxInRequests:  defaultGsMaxInRequests,
 		gsMaxOutRequests: defaultGsMaxOutRequests,
-		cidSchemaHint:    true,
 		strictAdsSelSeq:  true,
 	}
 
@@ -355,12 +353,5 @@ func MakeGeneralBlockHook(prevAdCid func(adCid cid.Cid) (cid.Cid, error)) BlockH
 		} else {
 			actions.SetNextSyncCid(prevCid)
 		}
-	}
-}
-
-func WithCidSchemaHint(enable bool) Option {
-	return func(c *config) error {
-		c.cidSchemaHint = enable
-		return nil
 	}
 }


### PR DESCRIPTION
Choosing a specific node prototype based on the cid schema hint adds significant code complexity without significant gain. 