### PR TITLE
test with synctext as artificial clock

### DIFF
--- a/pcache/provider_cache_test.go
+++ b/pcache/provider_cache_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25
+
 package pcache_test
 
 import (


### PR DESCRIPTION
Use `testing.synctest` for artificial clock in pcache tests. This make clock precisely controllable and does not require waiting in real time.